### PR TITLE
Add options to format-po formatter

### DIFF
--- a/.changeset/bright-foxes-invite.md
+++ b/.changeset/bright-foxes-invite.md
@@ -1,0 +1,5 @@
+---
+"@saykit/format-po": patch
+---
+
+Add formatter options for PO references and make line numbers opt-in

--- a/packages/format-po/src/formatter.ts
+++ b/packages/format-po/src/formatter.ts
@@ -1,7 +1,23 @@
 import type { Formatter } from '@saykit/config';
 import PO from 'pofile';
 
-function createPoFormatter(): Formatter {
+interface FormatterOptions {
+  /**
+   * Include source references in the generated PO file.
+   * @default true
+   */
+  references?:
+    | boolean
+    | {
+        /**
+         * Include line numbers in source references.
+         * @default true
+         */
+        lineNumbers?: boolean;
+      };
+}
+
+function createPoFormatter(options: FormatterOptions = {}): Formatter {
   return {
     extension: '.po',
 
@@ -50,7 +66,12 @@ function createPoFormatter(): Formatter {
         if (message.comments.length) comments.push(...message.comments);
         item.extractedComments = comments;
 
-        item.references = message.references;
+        if (options.references !== false) {
+          let references = message.references ?? [];
+          if (typeof options.references === 'object' && options.references.lineNumbers === false)
+            references = references.map((r) => r.split(':')[0]!);
+          item.references = Array.from(new Set(references)).sort();
+        }
         po.items.push(item);
       }
 

--- a/packages/format-po/src/formatter.ts
+++ b/packages/format-po/src/formatter.ts
@@ -69,7 +69,7 @@ function createPoFormatter(options: FormatterOptions = {}): Formatter {
         if (options.references !== false) {
           let references = message.references ?? [];
           if (typeof options.references === 'object' && options.references.lineNumbers === false)
-            references = references.map((r) => r.split(':')[0]!);
+            references = references.map((r) => r.replace(/:\d+$/, ''));
           item.references = Array.from(new Set(references)).sort();
         }
         po.items.push(item);


### PR DESCRIPTION
- Add options to format-po formatter
 - Add ability to not add references
 - Make line numbers opt-in
 - Refactor carbon saykit config to showcase different models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable options for PO file reference formatting, allowing control over whether line number references are included in translation entries.

* **Chores**
  * Updated example project structure to reflect simplified locale file organisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->