### PR TITLE
Add React integration docs

### DIFF
--- a/packages/integration-react/src/runtime/server.ts
+++ b/packages/integration-react/src/runtime/server.ts
@@ -44,8 +44,8 @@ export function unstable_createWithSay(say: Say) {
   /**
    * Wrap a server component so that a {@link Say} instance is initialised before render.
    */
-  return function withSay<P extends object>(
-    Component: (props: P & { locale: string; messages: Say.Messages }) => ReactNode,
+  return function withSay<P = unknown>(
+    Component: (props: PropsWithSay<P>) => ReactNode,
     getLocale: (props: P) => string | Promise<string>,
   ) {
     return async function WithSay(props: P) {
@@ -62,3 +62,5 @@ export function unstable_createWithSay(say: Say) {
     };
   };
 }
+
+export type PropsWithSay<P = unknown> = P & { locale: string; messages: Say.Messages };

--- a/packages/integration-react/src/runtime/server.ts
+++ b/packages/integration-react/src/runtime/server.ts
@@ -13,8 +13,8 @@ const serverContext = cache<() => SayRef>(() => ({ current: null }));
  */
 export function setSay(say: Say | ReadonlySay | (() => Say | ReadonlySay)): void {
   const ref = serverContext();
-  if (say instanceof Say) ref.current = say as ReadonlySay;
-  else ref.current = (say as () => ReadonlySay)();
+  if (say instanceof Say) ref.current = say.clone().freeze();
+  else ref.current = say().clone().freeze();
 }
 
 /**
@@ -49,7 +49,8 @@ export function unstable_createWithSay(say: Say) {
     getLocale: (props: P) => string | Promise<string>,
   ) {
     return async function WithSay(props: P) {
-      const locale = await getLocale(props);
+      const guess = await getLocale(props);
+      const locale = say.match(guess);
       await say.load(locale);
       say.activate(locale);
       setSay(say);

--- a/packages/integration/src/runtime.ts
+++ b/packages/integration/src/runtime.ts
@@ -202,12 +202,15 @@ export class Say<
    *
    * @returns The best matching locale, or the first locale if no matches are found
    */
-  match(guesses: string[]): Locale {
-    for (const guess of guesses) {
+  match(...guesses: (string | string[])[]): Locale {
+    const flat = guesses.flat();
+    if (flat.length === 0) return this.#locales[0]!;
+
+    for (const guess of flat) {
       if (this.#locales.includes(guess as Locale)) return guess as Locale;
     }
 
-    for (const guess of guesses) {
+    for (const guess of flat) {
       const prefix = guess.split('-')[0]!;
       const match = this.#locales.find((l) => l.startsWith(prefix));
       if (match) return match;

--- a/packages/integration/src/runtime.ts
+++ b/packages/integration/src/runtime.ts
@@ -175,11 +175,13 @@ export class Say<
    * @returns A clone of the Say instance
    */
   clone() {
-    return new Say({
+    const copy = new Say({
       locales: this.#locales,
       messages: Object.fromEntries(this.#messages) as any,
       loader: this.#loader,
     }) as unknown as this;
+    copy.#active = this.#active;
+    return copy;
   }
 
   /**

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -5,6 +5,8 @@ description: Learn how to define translatable messages using Saykit's macro synt
 
 Saykit provides several ways to define translatable messages using **macros** that are transformed at compile time by the Babel plugin.
 
+For JSX and TSX, see the [React integrations `<Say>` component](/integrations/react#say).
+
 ## Basic Messages
 
 The most common way to define a message is using the `say` tagged template.

--- a/website/content/integrations/carbon.mdx
+++ b/website/content/integrations/carbon.mdx
@@ -84,6 +84,8 @@ const client = new Client(
 // ...
 ```
 
+---
+
 Carbon still owns registration and execution. SayKit just provides the translated strings and locale-aware formatting.
 
 ## Mental Model

--- a/website/content/integrations/meta.json
+++ b/website/content/integrations/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Integrations",
   "icon": "Puzzle",
-  "pages": ["carbon"],
+  "pages": ["react", "carbon"],
   "collapsible": false
 }

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -1,0 +1,109 @@
+---
+title: React
+description: Use SayKit with React to localise your app
+---
+
+SayKit includes a React integration via `@saykit/react`.
+
+The React integration does two things:
+
+- provides a `<Say>` component for rendering translated JSX in both server and client components
+- provides a `<SayProvider>` context that supplies the active locale and messages to client components
+
+## `<Say>`
+
+`<Say>` is the primary way to render translated content, and works in both server and client components via the `react-server` export condition. Write your content naturally as JSX children, variables and elements are both supported.
+
+```tsx
+import { Say } from '@saykit/react';
+
+function CheckoutSummary({ items, total }: { items: number; total: string }) {
+  return (
+    <p>
+      <Say>
+        {items} items · total <strong>{total}</strong>
+      </Say>
+    </p>
+  );
+}
+```
+
+`<Say>` also exposes sub-components for pluralisation, ordinals, and select messages:
+
+```tsx
+<Say.Plural _={count} one="# item in your cart" other="# items in your cart" />
+
+<Say.Ordinal _={position} _1="1st" _2="2nd" _3="3rd" other="#th" />
+
+<Say.Select _={gender} male="He liked it" female="She liked it" other="They liked it" />
+```
+
+<Callout type="info">
+  `Say`, `Say.Plural`, `Say.Ordinal`, and `Say.Select` are macros, they must be used with the
+  relevant SayKit plugin for your build tool. See the [configuration
+  guide](/core-concepts/configuration) for setup.
+</Callout>
+
+## Client Components
+
+```ts
+import { SayProvider, useSay } from '@saykit/react/client';
+```
+
+### `<SayProvider>`
+
+Render `SayProvider` once near the top of your client tree, passing in the `locale` string and the `messages` catalogue for that locale.
+
+```tsx
+import { SayProvider } from '@saykit/react/client';
+
+const locale = say.match(...);
+await say.load(locale);
+say.activate(locale);
+const messages = say.messages;
+
+<SayProvider locale={locale} messages={messages}>
+  {children}
+</SayProvider>
+```
+
+Any client component below the provider can use `<Say>` directly, with no additional setup.
+
+### `useSay`
+
+If you need access to the `Say` instance itself in a client component, use `useSay()`. Keep in mind it will return a frozen `Say` instance, reflecting the locale and messages passed into the nearest `SayProvider`.
+
+```tsx
+function ConfirmButton({ count }: { count: number }) {
+  const say = useSay();
+  const handleClick = () => window.alert(say`Delete ${count} items?`);
+  return <button onClick={handleClick}><Say>Delete</Say></button>;
+}
+```
+
+## Server Usage
+
+```ts
+import { setSay, getSay, unstable_createWithSay } from '@saykit/react/server';
+```
+
+<Callout type="warning">
+  Server support is experimental. The exact integration API differs between frameworks, and
+  `unstable_createWithSay` may change before a stable release.
+</Callout>
+
+### `setSay`
+ 
+Call `setSay()` with your activated `Say` instance before any `<Say>` components render for the current request. It must be called before rendering, server components that use `<Say>` will throw if no instance has been registered.
+ 
+### `getSay`
+ 
+`getSay()` returns the `Say` instance registered for the current request by `setSay()`. It is the server equivalent of `useSay()`, useful when you need access to the instance itself rather than rendering through `<Say>`.
+
+## Mental Model
+
+A simple way to think about the integration is:
+
+- render translated strings and JSX with `<Say>` in any component, server or client
+- on the server, a `Say` instance is registered per-request so server components can resolve translations without a provider
+- on the client, `SayProvider` supplies the same locale and messages so client components hydrate correctly


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships the React integration documentation alongside two targeted runtime fixes that unblock it.

**Code changes:**
- `Say#clone()` now copies `#active` to the new instance, so `setSay(say)` (which calls `.clone().freeze()`) correctly preserves the active locale — the \"No active locale\" crash flagged in the previous review round is resolved.
- `Say#match()` is widened from `match(guesses: string[])` to a variadic `match(...guesses: (string | string[])[])`, allowing single-string calls (`say.match(guess)`) as used in the updated `unstable_createWithSay` HOC.

**Documentation (`website/content/integrations/react.mdx`):**
- New page covers `<Say>`, `<SayProvider>`, `useSay`, and the experimental server-side APIs (`setSay`, `getSay`, `unstable_createWithSay`).
- One documentation issue: the `SayProvider` code block contains `say.match(...)` where `...` is a bare syntactic placeholder, not valid JavaScript — readers who copy-paste this will hit a syntax error.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the say.match(...) docs placeholder — code changes are correct and the previously flagged runtime bug is resolved.

Both prior P0 concerns are addressed: clone() now copies #active, and match() accepts a single-string call. The only remaining issue is a syntax-error placeholder in the docs (say.match(...)) that will confuse readers. That warrants a targeted fix before merge, but the runtime behaviour is sound.

website/content/integrations/react.mdx — the say.match(...) placeholder on line 60 needs a concrete argument.

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: website/content/integrations/react.mdx
Line: 60

Comment:
**Placeholder `...` is not valid JavaScript**

`say.match(...)` is not executable code — `...` alone is not a spread expression and will cause a syntax error. Given the updated variadic signature `match(...guesses: (string | string[])[])`, a realistic example would be passing the `Accept-Language` header value directly:

```suggestion
const locale = say.match(request.headers['accept-language'] ?? '');
```

Or showing the array form is still supported:

```
const locale = say.match(['en-US', 'en', 'fr']);
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix clone method to preserve active loca..."](https://github.com/k0d13/saykit/commit/b706903bea625c7d65448a0feb20324615b7e1af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28874427)</sub>

<!-- /greptile_comment -->