### PR TITLE
Fix babel plugin to use parserOverride for more reliable transformation

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -42,11 +42,9 @@
   },
   "dependencies": {
     "@babel/core": "^7.29.0",
-    "@babel/parser": "^7.29.2",
-    "@saykit/config": "workspace:^",
-    "@types/babel__core": "^7.20.5"
+    "@saykit/config": "workspace:^"
   },
   "devDependencies": {
-    "@types/babel__parser": "^7.1.5"
+    "@types/babel__core": "^7.20.5"
   }
 }

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,29 +1,28 @@
 import { relative } from 'node:path';
-import type { PluginObj } from '@babel/core';
-import { parse } from '@babel/parser';
+import { type PluginObj, type parse as Parse } from '@babel/core';
 import { resolveConfig } from '@saykit/config/features/loader';
 
-export default function (): PluginObj {
+declare module '@babel/core' {
+  interface PluginObj {
+    parserOverride(code: string, opts: TransformOptions, parse: typeof Parse): ParseResult | null;
+  }
+}
+
+export default (): PluginObj => {
   const config = resolveConfig();
 
   return {
     name: 'saykit',
-    visitor: {
-      Program(path, state) {
-        const id_ = state.file.opts.filename;
-        if (!id_ || id_.includes('node_modules')) return;
-        const code = state.file.code ?? '';
+    visitor: {},
+    parserOverride(code, opts, parse) {
+      const id_ = opts.sourceFileName;
+      if (!id_ || id_.includes('node_modules')) return parse(code, opts);
 
-        const id = relative(process.cwd(), id_).replaceAll('\\', '/').split('?')[0]!;
-        const bucket = config.buckets.find((b) => b.match(id));
-        const transformed = bucket?.transformer.transform(code, id) ?? code;
+      const id = relative(process.cwd(), id_).replaceAll('\\', '/').split('?')[0]!;
+      const bucket = config.buckets.find((b) => b.match(id));
+      const transformed = bucket?.transformer.transform(code, id) ?? code;
 
-        if (transformed !== code) {
-          const ast = parse(transformed, state.file.opts.parserOpts as any);
-          path.replaceWith(ast.program);
-          path.skip();
-        }
-      },
+      return parse(transformed, opts);
     },
   };
-}
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,19 +254,13 @@ importers:
       '@babel/core':
         specifier: ^7.29.0
         version: 7.29.0
-      '@babel/parser':
-        specifier: ^7.29.2
-        version: 7.29.2
       '@saykit/config':
         specifier: workspace:^
         version: link:../config
+    devDependencies:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
-    devDependencies:
-      '@types/babel__parser':
-        specifier: ^7.1.5
-        version: 7.1.5
 
   packages/plugin-unplugin:
     dependencies:
@@ -2794,10 +2788,6 @@ packages:
 
   '@types/babel__generator@7.27.0':
     resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__parser@7.1.5':
-    resolution: {integrity: sha512-yyWPJg3KawM9ydArmt2q+UE6dhy0usfXNB1yxDv0gE27KbZXeFCDtqR2L4jdVxXqq7I9tvkL9zuSY/ZVgF6fXQ==}
-    deprecated: This is a stub types definition. @babel/parser provides its own type definitions, so you do not need this installed.
 
   '@types/babel__template@7.4.4':
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
@@ -7323,10 +7313,6 @@ snapshots:
   '@types/babel__generator@7.27.0':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@types/babel__parser@7.1.5':
-    dependencies:
-      '@babel/parser': 7.29.2
 
   '@types/babel__template@7.4.4':
     dependencies:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the Babel plugin to use `parserOverride` instead of the `visitor.Program` pattern. Rather than parsing the file with the default parser and then mutating the resulting AST (via `path.replaceWith`), the plugin now intercepts the parse step itself, transforms the source text up-front, and passes the modified code to the default parser. This eliminates the awkward "parse-replace-skip" dance and avoids potential mismatches between the outer Babel parse options and the inner `@babel/parser` call.

**Key changes:**
- `parserOverride` is a legitimate Babel plugin property (documented in the Babel parser FAQ) that is merged into the transform options before Babel calls its internal parser.
- `@babel/parser` and `@types/babel__parser` are correctly dropped as direct dependencies; `@types/babel__core` is moved to devDependencies.
- The module augmentation is necessary because `@types/babel__core` does not declare `parserOverride` on `PluginObj`, but the declared types for `opts` and `parse` don't perfectly match what Babel passes at runtime (see inline comment). This is a cosmetic/maintenance concern with no runtime impact.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the implementation is functionally correct and the only remaining issue is a minor TypeScript type-annotation inaccuracy in the module augmentation.

The `parserOverride` approach is the right tool for this job and is well-supported by Babel. Runtime behavior is correct: `opts.sourceFileName` resolves to the file path (Babel passes `sourceFileName` — uppercase — to the parser), and the delegated `parse(transformed, opts)` call works properly. The sole concern is a misleading type declaration (`TransformOptions` / `typeof Parse` where `ParserOptions` / `typeof babelParserParse` would be more accurate, and `parserOverride` should be optional), which has no effect on runtime correctness but could confuse future maintainers.

packages/plugin-babel/src/index.ts — specifically the `declare module '@babel/core'` block

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: packages/plugin-babel/src/index.ts
Line: 5-9

Comment:
**Inaccurate types in module augmentation**

The `opts` parameter is typed as `TransformOptions`, but at runtime Babel passes `ParserOptions` (from `@babel/parser`) as the second argument to `parserOverride`. Similarly, the `parse` third argument is typed as `typeof Parse` (i.e. `@babel/core.parse`) but Babel actually provides the low-level `@babel/parser.parse`.

This doesn't break at runtime because: (a) `@babel/core` happens to forward `sourceFileName` (uppercase N) to the parser as-is — a long-standing Babel inconsistency — so `opts.sourceFileName` resolves correctly; and (b) calling `parse(transformed, opts)` with parser opts against `@babel/parser.parse` is valid JavaScript. However, the declared types are misleading for future maintainers.

A more accurate signature would be:

```ts
declare module '@babel/core' {
  interface PluginObj {
    parserOverride?(
      code: string,
      opts: import('@babel/parser').ParserOptions,
      parse: typeof import('@babel/parser').parse
    ): import('@babel/types').File | null | undefined;
  }
}
```

Note also that `parserOverride` should be optional (`?`) here — if it's required, TypeScript would demand it on every `PluginObj` in this package's compilation scope (though in practice only this file uses `PluginObj` today).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix babel plugin to use parserOverride f..."](https://github.com/k0d13/saykit/commit/c24efbeeb05eda2e58c39f3f17e8d6bf0160c0c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29011291)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->