### PR TITLE
Replace separate sourceLocale config option with first item in locales

### DIFF
--- a/.changeset/humble-wolves-bet.md
+++ b/.changeset/humble-wolves-bet.md
@@ -1,0 +1,5 @@
+---
+"@saykit/config": patch
+---
+
+Replace `sourceLocale` config option with only first locale in `locales`

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ import po from '@saykit/format-po';
 import js from '@saykit/transform-js';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {

--- a/examples/carbon/saykit.config.ts
+++ b/examples/carbon/saykit.config.ts
@@ -3,7 +3,6 @@ import po from '@saykit/format-po';
 import js from '@saykit/transform-js';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {

--- a/examples/nextjs/saykit.config.ts
+++ b/examples/nextjs/saykit.config.ts
@@ -4,7 +4,6 @@ import js from '@saykit/transform-js';
 import jsx from '@saykit/transform-jsx';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {

--- a/examples/tanstack-start/saykit.config.ts
+++ b/examples/tanstack-start/saykit.config.ts
@@ -4,7 +4,6 @@ import js from '@saykit/transform-js';
 import jsx from '@saykit/transform-jsx';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,7 @@
+pre-commit:
+  commands:
+    format:
+      glob: '*.{js,ts,tsx,jsx,json,md}'
+      run: |
+        pnpm oxfmt {staged_files}
+        git add {staged_files}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "website"
   ],
   "scripts": {
+    "prepare": "lefthook",
     "check": "turbo run check",
     "lint": "turbo run lint && oxlint",
     "format": "turbo run format && oxfmt",
@@ -24,6 +25,7 @@
     "@changesets/config": "^3.1.4",
     "@types/node": "^25.8.0",
     "@vitest/coverage-v8": "^4.1.6",
+    "lefthook": "^2.1.6",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.65.0",
     "tsdown": "^0.21.10",

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -18,7 +18,6 @@ import po from '@saykit/format-po';
 import js from '@saykit/transform-js';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {

--- a/packages/config/src/features/workers/extract-worker.ts
+++ b/packages/config/src/features/workers/extract-worker.ts
@@ -50,7 +50,7 @@ export class BucketExtractWorker extends BucketWorker {
 
       const existingMessages = await readCatalogueMessages(this.bucket, locale);
       const nextMessages =
-        locale === this.config.sourceLocale
+        locale === this.config.locales[0]
           ? mergedMessages
           : reconcileLocaleMessages(existingMessages, mergedMessages);
 

--- a/packages/config/src/shapes.ts
+++ b/packages/config/src/shapes.ts
@@ -57,13 +57,8 @@ export const Bucket = z
   }));
 export type Bucket = z.infer<typeof Bucket>;
 
-export const Config = z
-  .object({
-    sourceLocale: z.string(),
-    locales: z.tuple([z.string()], z.string()),
-    buckets: Bucket.array(),
-  })
-  .refine((config) => config.sourceLocale === config.locales[0], {
-    error: 'sourceLocale must be the same as locales[0]',
-  });
+export const Config = z.object({
+  locales: z.tuple([z.string()], z.string()),
+  buckets: Bucket.array(),
+});
 export type Config = z.infer<typeof Config>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.6(vitest@4.1.6)
+      lefthook:
+        specifier: ^2.1.6
+        version: 2.1.6
       oxfmt:
         specifier: ^0.47.0
         version: 0.47.0
@@ -3978,6 +3981,60 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -8523,6 +8580,49 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/website/content/core-concepts/configuration.mdx
+++ b/website/content/core-concepts/configuration.mdx
@@ -12,7 +12,6 @@ import js from '@saykit/transform-js';
 import jsx from '@saykit/transform-jsx';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr', 'ja'],
   buckets: [
     {
@@ -25,7 +24,7 @@ export default defineConfig({
 });
 ```
 
-The config is validated by Zod at load time, mistakes get caught with a clear error.
+The first locale in `locales` is treated as the **source locale**: the language your code is written in, and the one extraction writes through as-is. Other locales are reconciled against it on every run. The config is validated by Zod at load time, mistakes get caught with a clear error.
 
 <Callout type="info">
   `defineConfig()` doesn't just type the config, it also runs it through the Zod schema and returns
@@ -49,14 +48,9 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 
 <TypeTable
   type={{
-    sourceLocale: {
-      description:
-        'The locale that source code is written in. Must equal the first entry of `locales`.',
-      type: 'string',
-      required: true,
-    },
     locales: {
-      description: 'Every locale your app supports, source first.',
+      description:
+        'Every locale your app supports. The first entry is the source locale (the language your code is written in).',
       type: '[string, ...string[]]',
       required: true,
     },
@@ -77,11 +71,11 @@ Locales are arbitrary strings. SayKit doesn't care whether you use BCP 47 (`en-G
 locales: ['en', 'fr-CA', 'es-419'];
 ```
 
-The **source locale** must be first. It's the locale your code is written in, and it's the one SayKit will rewrite into when it generates translation files from scratch.
+The **source locale** is whichever entry you list first. It's the locale your code is written in, and it's the one SayKit will rewrite into when it generates translation files from scratch. The runtime [`Say`](/core-concepts/runtime) class uses the same convention.
 
 <Callout type="warn">
-  Changing `sourceLocale` after you've written code in another language means SayKit will treat your
-  existing source messages as if they were the new source locale. Plan this early.
+  Reordering `locales` so that a different entry sits first means SayKit will treat your existing
+  source messages as if they were in the new source locale. Plan this early.
 </Callout>
 
 ## Buckets
@@ -185,7 +179,6 @@ import js from '@saykit/transform-js';
 import jsx from '@saykit/transform-jsx';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr', 'ja'],
   buckets: [
     {

--- a/website/content/getting-started/quickstart.mdx
+++ b/website/content/getting-started/quickstart.mdx
@@ -28,7 +28,6 @@ import js from '@saykit/transform-js';
 import jsx from '@saykit/transform-jsx';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {
@@ -43,7 +42,7 @@ export default defineConfig({
 
 This tells SayKit:
 
-- The source locale is `en`, and we also want `fr`.
+- The source locale is `en` (the first entry), and we also want `fr`.
 - Look for messages in any `.ts`/`.tsx` file under `src/`.
 - Write extracted messages to `src/locales/en.po` and `src/locales/fr.po`.
 - Use the PO formatter and the JS + JSX transformers.

--- a/website/content/guides/custom-transformer.mdx
+++ b/website/content/guides/custom-transformer.mdx
@@ -158,7 +158,6 @@ import js from '@saykit/transform-js';
 import vue from './my-transform-vue';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {

--- a/website/content/integrations/carbon.mdx
+++ b/website/content/integrations/carbon.mdx
@@ -30,7 +30,6 @@ import po from '@saykit/format-po';
 import js from '@saykit/transform-js';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {

--- a/website/content/reference/api/config.mdx
+++ b/website/content/reference/api/config.mdx
@@ -22,7 +22,6 @@ import po from '@saykit/format-po';
 import js from '@saykit/transform-js';
 
 export default defineConfig({
-  sourceLocale: 'en',
   locales: ['en', 'fr'],
   buckets: [
     {
@@ -45,13 +44,9 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 
 <TypeTable
   type={{
-    sourceLocale: {
-      description: 'The source locale (must equal `locales[0]`).',
-      type: 'string',
-      required: true,
-    },
     locales: {
-      description: 'All supported locales.',
+      description:
+        'All supported locales. The first entry is the source locale (the language your code is written in).',
       type: '[string, ...string[]]',
       required: true,
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Removed the explicit `sourceLocale` configuration option. The first locale in your `locales` array is now automatically used as the source locale.

**Documentation**
- Updated all configuration examples, guides, and API documentation across all supported frameworks to reflect the simplified configuration approach and new source locale behaviour.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/k0d13/saykit/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->