### PR TITLE
Remove auto-generation of .gitignore and update documentation accordingly

### DIFF
--- a/.changeset/remove-gitignore-generation.md
+++ b/.changeset/remove-gitignore-generation.md
@@ -1,0 +1,5 @@
+---
+'@saykit/config': minor
+---
+
+Stop auto-generating a `.gitignore` next to catalogue files. SayKit no longer writes or overwrites a `.gitignore` in the output directory, leaving it to you to decide which generated files (e.g. `*.d.ts` locale declarations) to commit or ignore. This makes it possible to commit declaration files so CI can type-check without an extra extraction step.

--- a/packages/config/src/features/catalogue/path.ts
+++ b/packages/config/src/features/catalogue/path.ts
@@ -11,8 +11,3 @@ export function expandBucketOutputPath(
     .replaceAll('{extension}', extension.slice(1));
   return resolve(outputMessageTemplate);
 }
-
-export function expandBucketOutputIgnoreDirectory(bucket: Bucket) {
-  const [prefix] = bucket.output.split('{locale}');
-  return resolve(prefix || '.');
-}

--- a/packages/config/src/features/catalogue/storage.ts
+++ b/packages/config/src/features/catalogue/storage.ts
@@ -1,11 +1,11 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 import type { Bucket, Message } from '~/shapes.js';
-import { expandBucketOutputIgnoreDirectory, expandBucketOutputPath } from './path.js';
+import { expandBucketOutputPath } from './path.js';
 
 const DECLARATION_CONTENT = `
-declare const translations: Record<string, string>;
-export default translations;
+declare const messages: Record<string, string>;
+export default messages;
 `.trim();
 
 export async function readCatalogueMessages(
@@ -27,15 +27,10 @@ export async function writeCatalogueMessages(
   const existingContent = await readFile(path, 'utf8').catch(() => undefined);
   const catalogueContent = bucket.formatter.stringify(messages, { locale, existingContent });
   const declarationPath = `${path}.d.ts`;
-  const ignoreDirectory = expandBucketOutputIgnoreDirectory(bucket);
-  const ignorePath = join(ignoreDirectory, '.gitignore');
-  const ignoreContent = `.gitignore\n*.${bucket.formatter.extension.slice(1)}.d.ts`;
 
   await mkdir(dirname(path), { recursive: true });
-  await mkdir(ignoreDirectory, { recursive: true });
   await Promise.all([
     writeFile(path, catalogueContent),
     writeFile(declarationPath, DECLARATION_CONTENT),
-    writeFile(ignorePath, ignoreContent),
   ]);
 }

--- a/website/content/core-concepts/extraction.mdx
+++ b/website/content/core-concepts/extraction.mdx
@@ -27,7 +27,6 @@ src/locales/
   en.po.d.ts    # auto-generated TS declaration for *.po imports
   fr.po         # other locales, reconciled with the source, your translations preserved
   fr.po.d.ts
-  .gitignore    # marks generated declaration files
 ```
 
 <Callout type="info">
@@ -119,13 +118,12 @@ This fails the build if anyone forgot to run extraction, useful for keeping tran
 
 For each bucket output:
 
-| File               | Purpose                                                             |
-| ------------------ | ------------------------------------------------------------------- |
-| `{locale}.po`      | The catalogue, in whatever format the bucket's formatter produces   |
-| `{locale}.po.d.ts` | Generic TS declaration so `import en from './locales/en.po'` types  |
-| `.gitignore`       | Marks `*.po.d.ts` as generated (commit `.po` files, ignore `.d.ts`) |
+| File               | Purpose                                                            |
+| ------------------ | ------------------------------------------------------------------ |
+| `{locale}.po`      | The catalogue, in whatever format the bucket's formatter produces  |
+| `{locale}.po.d.ts` | Generic TS declaration so `import en from './locales/en.po'` types |
 
-The `.gitignore` is written to the output directory automatically. You can override or extend it, SayKit will only write a missing one.
+SayKit doesn't write a `.gitignore` — it's up to you which generated files to commit or ignore. The `.po` catalogues are canonical and should be committed; the `.po.d.ts` declarations are regenerated on every extraction, so you can either commit them (handy for CI type-checking) or ignore them via your project's `.gitignore`.
 
 ## Next
 

--- a/website/content/getting-started/quickstart.mdx
+++ b/website/content/getting-started/quickstart.mdx
@@ -118,7 +118,6 @@ src/locales/
   en.po.d.ts    # auto-generated TS declaration
   fr.po         # other locales, ready for translation
   fr.po.d.ts
-  .gitignore    # marks generated declaration files
 ```
 
 For iterative development, use watch mode:

--- a/website/content/guides/typed-messages.mdx
+++ b/website/content/guides/typed-messages.mdx
@@ -11,7 +11,6 @@ src/locales/
   en.po.d.ts
   fr.po
   fr.po.d.ts
-  .gitignore     # marks *.po.d.ts as generated
 ```
 
 ```ts
@@ -40,19 +39,12 @@ In short: **you never reference an id from application code**. The build does th
 
 ## Committing translation files
 
-The `.gitignore` next to your translation files looks like this:
-
-```text title="src/locales/.gitignore"
-.gitignore
-*.po.d.ts
-```
-
-That means:
+SayKit doesn't manage a `.gitignore` for you — it's up to you which generated files to commit or ignore. A common setup:
 
 - **Commit** the `.po` files. They're the canonical translations.
-- **Ignore** the `.po.d.ts` files. SayKit regenerates them on every extraction.
+- Either commit or ignore the `.po.d.ts` files. SayKit regenerates them on every extraction, so ignoring them keeps diffs quiet; committing them lets CI type-check without an extra extraction step.
 
-If you ever rename your formatter's extension, the `*.po.d.ts` line will update on the next extraction.
+If you want to ignore the declarations, add a line like `*.po.d.ts` to your project's `.gitignore`.
 
 ## Importing in different bundlers
 

--- a/website/content/reference/cli.mdx
+++ b/website/content/reference/cli.mdx
@@ -56,7 +56,7 @@ For each bucket:
 4. Hashes ids for messages without a custom id.
 5. Reconciles target locales against the source, preserving existing translations, adding new entries, removing stale ones.
 6. Writes one catalogue file per locale via the bucket's formatter.
-7. Writes a `.d.ts` declaration next to each catalogue, and a `.gitignore` next to those.
+7. Writes a `.d.ts` declaration next to each catalogue.
 
 ### Exit codes
 


### PR DESCRIPTION
Closes #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalogue output paths now support an `{extension}` placeholder.
  * Generated catalogue declarations export `messages` instead of `translations`.

* **Bug Fixes**
  * SayKit no longer creates or updates `.gitignore` files alongside extracted catalogues.
  * Projects can now choose whether generated declaration files are committed or ignored.

* **Documentation**
  * Updated extraction, quickstart, typed messages, and CLI documentation to reflect the revised file-handling behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->