### PR TITLE
Add whitespace prop to <Say> component and update renderer logic

### DIFF
--- a/.changeset/whitespace-prop.md
+++ b/.changeset/whitespace-prop.md
@@ -1,0 +1,22 @@
+---
+"@saykit/transform-jsx": minor
+"@saykit/config": minor
+"@saykit/react": minor
+---
+
+Add a `whitespace` prop to `<Say>` for controlling whitespace-only text nodes in the rendered output.
+
+When multiple elements sit inside a `<Say>` (e.g. two `<Text>` children), the literal whitespace between them is preserved in the compiled output as a bare string node. This is fine on the web, but stricter environments like React Native error when a string is rendered outside of a text component.
+
+Set `whitespace={false}` to drop whitespace-only text nodes from the rendered result:
+
+```tsx
+<View>
+  <Say whitespace={false}>
+    <Text>Hello</Text>
+    <Text>World</Text>
+  </Say>
+</View>
+```
+
+The default remains `true`, preserving existing (web-compatible) behaviour.

--- a/packages/config/src/features/messages/types.ts
+++ b/packages/config/src/features/messages/types.ts
@@ -59,6 +59,7 @@ export class CompositeMessage extends Base {
     public readonly references: string[],
     public readonly children: Message[],
     public readonly accessor: any,
+    public readonly whitespace?: boolean,
   ) {
     super();
   }

--- a/packages/integration-react/package.json
+++ b/packages/integration-react/package.json
@@ -45,6 +45,8 @@
   "scripts": {
     "check": "tsc --noEmit",
     "build": "tsdown",
+    "test": "vitest",
+    "coverage": "vitest run --coverage",
     "prepack": "pnpm build"
   },
   "dependencies": {

--- a/packages/integration-react/src/components/renderer.test.ts
+++ b/packages/integration-react/src/components/renderer.test.ts
@@ -1,0 +1,66 @@
+import { type ReactNode, isValidElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import { Renderer } from '~/components/renderer.js';
+
+// The compiled message for two adjacent elements inside a `<Say>` keeps the
+// literal whitespace between the slots, e.g.
+//
+//   <View>
+//     <Say>
+//       <Text>Hello</Text>
+//       <Text>World</Text>
+//     </Say>
+//   </View>
+//
+// becomes the message `<0>Hello</0> <1>World</1>`. On the web the bare space
+// between the two elements is harmless, but React Native throws because a
+// string is being rendered outside of a text component.
+
+/** Map every slot to a plain wrapper so the tree is easy to inspect. */
+const components = { 0: 'span', 1: 'span' } as const;
+
+/** Collect every leaf node (string or element) produced by the renderer. */
+function leaves(node: ReactNode): ReactNode[] {
+  if (node == null || typeof node === 'boolean') return [];
+  if (Array.isArray(node)) return node.flatMap(leaves);
+  if (isValidElement(node)) return [node, ...leaves((node.props as { children?: ReactNode }).children)];
+  return [node];
+}
+
+/** All bare string nodes rendered anywhere in the tree. */
+function strings(node: ReactNode) {
+  return leaves(node).filter((n): n is string => typeof n === 'string');
+}
+
+describe('Renderer whitespace handling', () => {
+  const html = '<0>Hello</0> <1>World</1>';
+
+  it('keeps whitespace between elements by default (web behaviour)', () => {
+    const tree = Renderer({ html, components });
+    expect(strings(tree)).toEqual(['Hello', ' ', 'World']);
+  });
+
+  it('keeps whitespace when whitespace is explicitly true', () => {
+    const tree = Renderer({ html, components, whitespace: true });
+    expect(strings(tree)).toContain(' ');
+  });
+
+  it('drops the whitespace-only node when whitespace is false (React Native)', () => {
+    const tree = Renderer({ html, components, whitespace: false });
+    // The space between the two <Text> slots is gone...
+    expect(strings(tree)).toEqual(['Hello', 'World']);
+    // ...so nothing renders a bare whitespace string outside of an element.
+    expect(strings(tree)).not.toContain(' ');
+  });
+
+  it('preserves meaningful text around elements when stripping whitespace', () => {
+    // `Hi <0>there</0>!` — the significant spaces are part of real words here.
+    const tree = Renderer({ html: 'Hi <0>there</0>!', components, whitespace: false });
+    expect(strings(tree)).toEqual(['Hi ', 'there', '!']);
+  });
+
+  it('drops leading and trailing whitespace-only nodes when stripping', () => {
+    const tree = Renderer({ html: ' <0>Hello</0> ', components, whitespace: false });
+    expect(strings(tree)).toEqual(['Hello']);
+  });
+});

--- a/packages/integration-react/src/components/renderer.ts
+++ b/packages/integration-react/src/components/renderer.ts
@@ -10,7 +10,21 @@ type ComponentsMap = Record<string | number, string | ComponentType<PropsWithChi
 type ComponentResolver = (tag?: string) => string | ComponentType<PropsWithChildren> | undefined;
 type ComponentsProp = ComponentsMap | ComponentResolver;
 
-export function Renderer({ html, components }: { html: string; components: ComponentsProp }) {
+export function Renderer({
+  html,
+  components,
+  whitespace = true,
+}: {
+  html: string;
+  components: ComponentsProp;
+  /**
+   * Whether to keep whitespace-only text nodes in the rendered output.
+   * Defaults to `true`. Set to `false` to drop them, which is useful in
+   * environments like React Native where bare strings cannot sit between
+   * elements.
+   */
+  whitespace?: boolean;
+}) {
   function getComponent(tag?: string) {
     if (typeof components === 'function') return components(tag) ?? tag ?? Fragment;
     return tag && tag in components ? components[tag]! : Fragment;
@@ -55,7 +69,7 @@ export function Renderer({ html, components }: { html: string; components: Compo
         let textEnd = input.indexOf('<', i);
         if (textEnd === -1) textEnd = input.length;
         const text = input.slice(i, textEnd);
-        current.push(text);
+        if (whitespace || text.trim() !== '') current.push(text);
         i = textEnd;
       }
     }

--- a/packages/integration-react/src/runtime/index.ts
+++ b/packages/integration-react/src/runtime/index.ts
@@ -20,18 +20,22 @@ declare function GET_SAY(): import('saykit').ReadonlySay;
  * @remark This is a macro and must be used with the relevant saykit plugin
  */
 // @ts-expect-error macro
-export function Say(props: PropsWithChildren<Disallow<{ context?: string }, 'id'>>): ReactElement;
-export function Say(props: { id: string; [match: string]: unknown }) {
+export function Say(
+  props: PropsWithChildren<Disallow<{ context?: string; whitespace?: boolean }, 'id'>>,
+): ReactElement;
+export function Say(props: { id: string; whitespace?: boolean; [match: string]: unknown }) {
   if (!('id' in props))
     throw new Error("'Say' is a macro and must be used with the relevant saykit plugin", {
       cause: new Error("The 'id' property is required for a descriptor"),
     });
 
   const say = GET_SAY();
-  const descriptor = resolveJsxSafePropKeys(props);
+  const { whitespace, ...rest } = props;
+  const descriptor = resolveJsxSafePropKeys(rest);
 
   return createElement(Renderer, {
     html: say.call(descriptor),
+    whitespace,
     components(tag?: string) {
       if (tag && tag in descriptor && isValidElement(descriptor[tag])) {
         const element = descriptor[tag]! as ReactElement;

--- a/packages/integration-react/vitest.config.ts
+++ b/packages/integration-react/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './.coverage',
+    },
+  },
+});

--- a/packages/transform-jsx/src/generator.ts
+++ b/packages/transform-jsx/src/generator.ts
@@ -13,6 +13,14 @@ export function generateSayJSXElement(message: CompositeMessage) {
 
   const attributes = [
     t.jsxAttribute(t.jsxIdentifier('id'), t.stringLiteral(id)),
+    ...(message.whitespace === undefined
+      ? []
+      : [
+          t.jsxAttribute(
+            t.jsxIdentifier('whitespace'),
+            t.jsxExpressionContainer(t.booleanLiteral(message.whitespace)),
+          ),
+        ]),
     ...children.map(([k, e]) =>
       t.jsxAttribute(t.jsxIdentifier(Number.isNaN(+k) ? k : `_${k}`), t.jsxExpressionContainer(e)),
     ),

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -104,6 +104,25 @@ describe('parseJSXContainerElement', () => {
     const result = parser.parseJSXContainerElement(makeSayContainer([t.jsxText('Hi')]));
     expect(result!.descriptor).toEqual({ id: undefined, context: undefined });
   });
+
+  it('leaves whitespace undefined when the attribute is absent', () => {
+    const result = parser.parseJSXContainerElement(makeSayContainer([t.jsxText('Hi')]));
+    expect(result!.whitespace).toBeUndefined();
+  });
+
+  it('reads whitespace={false} attribute as a boolean', () => {
+    const result = parser.parseJSXContainerElement(
+      makeSayContainer([t.jsxText('Hi')], [exprAttr('whitespace', t.booleanLiteral(false))]),
+    );
+    expect(result!.whitespace).toBe(false);
+  });
+
+  it('treats a bare whitespace attribute as true', () => {
+    const result = parser.parseJSXContainerElement(
+      makeSayContainer([t.jsxText('Hi')], [attr('whitespace', null)]),
+    );
+    expect(result!.whitespace).toBe(true);
+  });
 });
 
 // ─── parseJSXOpeningElement ──────────────────────────────────────────────────

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -43,6 +43,7 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
     element.openingElement.attributes,
     'context',
   );
+  const whitespace = findAttributeValueAsBoolean(element.openingElement.attributes, 'whitespace');
 
   return new CompositeMessage(
     { id: descriptorId, context: descriptorContext },
@@ -50,6 +51,7 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
     [],
     children,
     accessor as t.Expression,
+    whitespace,
   );
 }
 
@@ -196,6 +198,21 @@ function findAttributeValueIfExpressionOrStringLiteral(
         return attribute.value.expression;
       if (t.isStringLiteral(attribute.value)) return attribute.value;
     }
+  }
+  return undefined;
+}
+
+function findAttributeValueAsBoolean(
+  attributes: (t.JSXAttribute | t.JSXSpreadAttribute)[],
+  identifier: string,
+) {
+  for (const attribute of attributes) {
+    if (!t.isJSXAttribute(attribute)) continue;
+    if (!t.isJSXIdentifier(attribute.name) || attribute.name.name !== identifier) continue;
+    // Bare attribute (e.g. `whitespace`) implies `true`.
+    if (attribute.value == null) return true;
+    if (t.isJSXExpressionContainer(attribute.value) && t.isBooleanLiteral(attribute.value.expression))
+      return attribute.value.expression.value;
   }
   return undefined;
 }

--- a/website/lib/layout.shared.tsx
+++ b/website/lib/layout.shared.tsx
@@ -17,7 +17,7 @@ export function baseOptions(): BaseLayoutProps {
     links: [
       {
         text: 'Community',
-        url: 'https://discord.gg/vGFBFf3K2',
+        url: 'https://discord.gg/bqgAj65Em5',
         icon: <MessageCircleMore />,
       },
     ],


### PR DESCRIPTION
- Introduced a `whitespace` prop to control whitespace-only text nodes in the <Say> component.
- Updated Renderer function to handle the new prop, allowing for better compatibility with React Native.
- Added tests to verify whitespace handling behavior.
- Updated package.json to include test and coverage scripts.
- Added Vitest configuration for testing.

Closes #25 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `whitespace` option to `<Say>` for controlling whitespace-only text between child elements.
  * Whitespace is preserved by default; setting `whitespace={false}` removes whitespace-only nodes for stricter runtimes.
  * Supports bare `whitespace` attributes and explicit boolean values.

* **Documentation**
  * Added usage guidance and an example for the new option.

* **Tests**
  * Added coverage for whitespace parsing, rendering, and preservation of meaningful spaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->