### PR TITLE
Write extraction only to the source locale

### DIFF
--- a/.changeset/source-locale-extraction.md
+++ b/.changeset/source-locale-extraction.md
@@ -1,0 +1,9 @@
+---
+"@saykit/config": minor
+"babel-plugin-saykit": minor
+"unplugin-saykit": minor
+---
+
+Write extraction only to the source locale, add message fallbacks, and add a `clean` command.
+
+Extracted messages are now written to the source locale catalogue only, rather than to every locale. Other locales fall back to the source message when a translation is missing, keeping non-source catalogues focused on real translations. A new `clean` command removes generated catalogue output.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ console.log(say`Hello, ${'world'}!`);
 pnpm saykit extract
 ```
 
+Extraction only writes the source locale (the first entry in `locales`); new locales get an empty
+placeholder file and existing translation files are left untouched, keeping diffs small and leaving
+translated content to your TMS. Untranslated keys fall back to a configurable fallback chain (and
+ultimately the source string) at load time, and `saykit clean` can reconcile other locale files
+against the source when you want to manage them yourself.
+
 For framework-specific setup, see the React and Carbon integration docs.
 
 ## Development

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -21,6 +21,12 @@ import js from '@saykit/transform-js';
 
 export default defineConfig({
   locales: ['en', 'fr'],
+  // Optional per-locale fallback chains, most specific first. The source locale
+  // (the first entry in `locales`) is always the final fallback.
+  fallbackLocales: {
+    'en-NZ': ['en-GB'],
+    'es-MX': 'es',
+  },
   buckets: [
     {
       include: ['src/**/*.ts'],
@@ -37,7 +43,21 @@ export default defineConfig({
 ```sh
 saykit extract           # extract messages once
 saykit extract --watch   # extract and watch for changes
+saykit clean             # reconcile other locales against the source
 ```
+
+Extraction only writes the **source** locale (the first entry in `locales`). Locales that don't
+have a file yet are bootstrapped with an empty, header-only catalogue so a TMS can register them;
+existing translation files are left untouched. Translated content is owned by your TMS.
+
+At load time (via the unplugin or Babel plugin), each locale module is filled from its fallback
+chain, so an untranslated key resolves to a fallback locale and ultimately the source string — the
+runtime still loads a single locale.
+
+`saykit clean` reconciles every non-source locale against the current source catalogue: it adds
+missing keys (untranslated), drops entries that no longer exist in the source, and preserves any
+existing translations. Use it when you want to propagate source changes into locale files yourself
+rather than leaving it to your TMS.
 
 ## Documentation
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -37,6 +37,16 @@
         "default": "./dist/index.mjs"
       }
     },
+    "./features/catalogue": {
+      "require": {
+        "types": "./dist/features/catalogue/index.d.cts",
+        "default": "./dist/features/catalogue/index.cjs"
+      },
+      "import": {
+        "types": "./dist/features/catalogue/index.d.mts",
+        "default": "./dist/features/catalogue/index.mjs"
+      }
+    },
     "./features/loader": {
       "require": {
         "types": "./dist/features/loader/index.d.cts",

--- a/packages/config/src/commands/clean.ts
+++ b/packages/config/src/commands/clean.ts
@@ -1,0 +1,31 @@
+import { Command } from '@commander-js/extra-typings';
+import { reconcileLocaleMessages } from '~/features/catalogue/merge.js';
+import { readCatalogueMessages, writeCatalogueMessages } from '~/features/catalogue/storage.js';
+import { resolveConfig } from '~/features/loader/index.js';
+import Logger from '~/features/logger.js';
+
+export default new Command('clean')
+  .description('Reconcile non-source locale files against the source locale')
+  .option('-v, --verbose', 'enable verbose logging', false)
+  .option('-q, --quiet', 'suppress all logging', false)
+  .action(async (options) => {
+    const config = resolveConfig();
+    const logger = new Logger(options);
+    logger.header('🧹 Cleaning Locales');
+
+    const [sourceLocale, ...otherLocales] = config.locales;
+
+    for (const bucket of config.buckets) {
+      const sourceMessages = await readCatalogueMessages(bucket, sourceLocale);
+      logger.info(`Reconciling ${otherLocales.length} locale(s) against ${sourceLocale}`);
+
+      for (const locale of otherLocales) {
+        logger.step(`Reconciling ${locale}`);
+        const existingMessages = await readCatalogueMessages(bucket, locale);
+        const reconciledMessages = reconcileLocaleMessages(existingMessages, sourceMessages);
+        await writeCatalogueMessages(bucket, locale, reconciledMessages);
+      }
+    }
+
+    logger.success('Locales cleaned');
+  });

--- a/packages/config/src/commands/index.ts
+++ b/packages/config/src/commands/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { program } from '@commander-js/extra-typings';
+import clean from './clean.js';
 import extract from './extract.js';
 
 program
@@ -8,4 +9,5 @@ program
   .helpOption('-h, --help', 'Display help for command')
   .helpCommand('help [command]', 'Display help for command')
   .addCommand(extract)
+  .addCommand(clean)
   .parse();

--- a/packages/config/src/features/catalogue/index.ts
+++ b/packages/config/src/features/catalogue/index.ts
@@ -1,0 +1,4 @@
+export * from './merge.js';
+export * from './path.js';
+export * from './record.js';
+export * from './storage.js';

--- a/packages/config/src/features/catalogue/merge.test.ts
+++ b/packages/config/src/features/catalogue/merge.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '~/shapes.js';
+import { mergeExtractedMessages, reconcileLocaleMessages } from './merge.js';
+
+const msg = (m: Partial<Message> & { message: string }): Message => ({
+  comments: [],
+  references: [],
+  ...m,
+});
+
+describe('mergeExtractedMessages', () => {
+  it('dedupes by id and unions comments and references', () => {
+    const merged = mergeExtractedMessages([
+      msg({ message: 'Hello', id: 'greeting', comments: ['a'], references: ['x.ts:1'] }),
+      msg({ message: 'Hello', id: 'greeting', comments: ['b'], references: ['y.ts:2'] }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.comments).toEqual(['a', 'b']);
+    expect(merged[0]!.references).toEqual(['x.ts:1', 'y.ts:2']);
+  });
+
+  it('dedupes id-less messages by message and context hash', () => {
+    const merged = mergeExtractedMessages([
+      msg({ message: 'Save', context: 'button', comments: ['one'] }),
+      msg({ message: 'Save', context: 'button', comments: ['two'] }),
+      msg({ message: 'Save', context: 'menu' }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+    const button = merged.find((m) => m.context === 'button')!;
+    expect(button.comments).toEqual(['one', 'two']);
+  });
+});
+
+describe('reconcileLocaleMessages', () => {
+  const next = [
+    msg({
+      message: 'Hello',
+      id: 'greeting',
+      context: 'top',
+      comments: ['new'],
+      references: ['a.ts:1'],
+    }),
+    msg({ message: 'New string', id: 'fresh' }),
+  ];
+
+  it('preserves existing translations while refreshing source metadata', () => {
+    const existing = [
+      msg({
+        message: 'Hello (old)',
+        id: 'greeting',
+        translation: 'Bonjour',
+        comments: ['old'],
+        references: ['z.ts:9'],
+      }),
+    ];
+
+    const reconciled = reconcileLocaleMessages(existing, next);
+    const greeting = reconciled.find((m) => m.id === 'greeting')!;
+
+    expect(greeting.translation).toBe('Bonjour'); // translation kept
+    expect(greeting.message).toBe('Hello'); // source text refreshed
+    expect(greeting.context).toBe('top');
+    expect(greeting.comments).toEqual(['new']);
+    expect(greeting.references).toEqual(['a.ts:1']);
+  });
+
+  it('adds untranslated entries for new source keys', () => {
+    const reconciled = reconcileLocaleMessages([], next);
+    const fresh = reconciled.find((m) => m.id === 'fresh')!;
+
+    expect(fresh.translation).toBeUndefined();
+  });
+
+  it('drops entries that no longer exist in the source', () => {
+    const existing = [msg({ message: 'Gone', id: 'orphan', translation: 'Parti' })];
+
+    const reconciled = reconcileLocaleMessages(existing, next);
+
+    expect(reconciled.some((m) => m.id === 'orphan')).toBe(false);
+  });
+});

--- a/packages/config/src/features/catalogue/merge.ts
+++ b/packages/config/src/features/catalogue/merge.ts
@@ -37,13 +37,11 @@ export function reconcileLocaleMessages(existingMessages: Message[], nextMessage
     const existingMessage = existingMessagesByKey.get(key);
 
     map.set(key, {
-      message: message.message,
-      translation: undefined,
-      ...existingMessage,
-      id: message.id,
-      context: message.context,
-      comments: message.comments,
-      references: message.references,
+      // Refresh every field from the source of truth, but keep any existing
+      // translation. Keys absent from `next` are dropped (orphans), keys new to
+      // the source arrive untranslated.
+      ...message,
+      translation: existingMessage?.translation,
     });
 
     return map;

--- a/packages/config/src/features/catalogue/record.test.ts
+++ b/packages/config/src/features/catalogue/record.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { Bucket, Config } from '~/shapes.js';
+import { assembleCatalogueRecord, resolveFallbackChain } from './record.js';
+
+const config = (fallbackLocales?: Config['fallbackLocales']) =>
+  ({ locales: ['en', 'en-GB', 'en-NZ', 'fr'], fallbackLocales, buckets: [] }) as unknown as Config;
+
+describe('resolveFallbackChain', () => {
+  it('always ends at the source locale', () => {
+    expect(resolveFallbackChain(config(), 'fr')).toEqual(['fr', 'en']);
+  });
+
+  it('expands a configured chain, most specific first, then the source', () => {
+    expect(resolveFallbackChain(config({ 'en-NZ': ['en-GB'] }), 'en-NZ')).toEqual([
+      'en-NZ',
+      'en-GB',
+      'en',
+    ]);
+  });
+
+  it('accepts a single fallback locale as a string', () => {
+    expect(resolveFallbackChain(config({ 'en-NZ': 'en-GB' }), 'en-NZ')).toEqual([
+      'en-NZ',
+      'en-GB',
+      'en',
+    ]);
+  });
+
+  it('dedupes when the locale is already the source', () => {
+    expect(resolveFallbackChain(config(), 'en')).toEqual(['en']);
+  });
+});
+
+describe('assembleCatalogueRecord', () => {
+  const bucket = {
+    formatter: { parse: (content: string) => JSON.parse(content) },
+  } as unknown as Bucket;
+
+  it('lets more specific locales win, skips empty files, and falls back to source text', () => {
+    // Contents are most-specific first, matching `resolveCatalogueSources`.
+    const record = assembleCatalogueRecord(bucket, [
+      JSON.stringify([{ message: 'C', translation: 'C-NZ', id: 'c' }]),
+      '', // a fallback locale with no file yet
+      JSON.stringify([
+        { message: 'A', id: 'a' },
+        { message: 'C', translation: 'C-source', id: 'c' },
+      ]),
+    ]);
+
+    expect(record).toEqual({ a: 'A', c: 'C-NZ' });
+  });
+});

--- a/packages/config/src/features/catalogue/record.ts
+++ b/packages/config/src/features/catalogue/record.ts
@@ -1,0 +1,51 @@
+import { resolve } from 'node:path';
+import { generateHash } from '~/features/messages/hash.js';
+import type { Bucket, Config } from '~/shapes.js';
+import { expandBucketOutputPath } from './path.js';
+
+/**
+ * Resolve the fallback chain for a locale, most specific first. The source
+ * locale (the first configured locale) is always the final fallback, so an
+ * untranslated key ultimately resolves to the source string.
+ */
+export function resolveFallbackChain(config: Config, locale: string) {
+  const source = config.locales[0];
+  const configured = config.fallbackLocales?.[locale];
+  const fallbacks = configured ? (Array.isArray(configured) ? configured : [configured]) : [];
+  return Array.from(new Set([locale, ...fallbacks, source]));
+}
+
+/**
+ * Resolve the catalogue files that contribute to a locale module, most specific
+ * first. When the path does not map to a configured locale it is loaded on its
+ * own.
+ */
+export function resolveCatalogueSources(config: Config, bucket: Bucket, path: string) {
+  const resolved = resolve(path);
+  const locale = config.locales.find((l) => expandBucketOutputPath(bucket, l) === resolved);
+  const sources = locale
+    ? resolveFallbackChain(config, locale).map((l) => expandBucketOutputPath(bucket, l))
+    : [resolved];
+  return { locale, sources };
+}
+
+/**
+ * Assemble a `{ id: string }` record from catalogue file contents. `contents`
+ * must be aligned with the `sources` returned by {@link resolveCatalogueSources}
+ * (most specific first): more specific locales override their fallbacks, and any
+ * key still untranslated falls back to its source message.
+ */
+export function assembleCatalogueRecord(bucket: Bucket, contents: string[]) {
+  const record: Record<string, string> = {};
+
+  // Apply least specific first so the most specific locale wins each key.
+  for (const content of [...contents].reverse()) {
+    if (!content) continue;
+    for (const message of bucket.formatter.parse(content)) {
+      const key = message.id || generateHash(message.message, message.context);
+      record[key] = message.translation || message.message;
+    }
+  }
+
+  return record;
+}

--- a/packages/config/src/features/workers/extract-worker.test.ts
+++ b/packages/config/src/features/workers/extract-worker.test.ts
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Logger from '~/features/logger.js';
+import type { Bucket, Config, Message } from '~/shapes.js';
+
+vi.mock('../catalogue/extractor', () => ({ extractMessagesFromFile: vi.fn() }));
+
+const { extractMessagesFromFile } = await import('../catalogue/extractor');
+const { BucketExtractWorker } = await import('./extract-worker.js');
+
+const msg = (m: Partial<Message> & { message: string }): Message => ({
+  comments: [],
+  references: [],
+  ...m,
+});
+
+const logger = new Logger({ quiet: true });
+
+let dir: string;
+let bucket: Bucket;
+let config: Config;
+
+const localePath = (locale: string) => join(dir, locale, 'messages.json');
+const readLocale = (locale: string) =>
+  JSON.parse(readFileSync(localePath(locale), 'utf8')) as Message[];
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'saykit-extract-'));
+  bucket = {
+    include: ['src/**/*.ts'],
+    match: (id: string) => id.endsWith('.ts'),
+    output: Object.assign(join(dir, '{locale}', 'messages.{extension}'), {
+      match: (id: string) => id.endsWith('messages.json'),
+    }),
+    formatter: {
+      extension: '.json',
+      parse: (content: string) => JSON.parse(content) as Message[],
+      stringify: (messages: Message[]) => JSON.stringify(messages),
+    },
+  } as unknown as Bucket;
+  config = { locales: ['en', 'fr', 'de'], buckets: [bucket] } as unknown as Config;
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+async function extract(messages: Message[]) {
+  vi.mocked(extractMessagesFromFile).mockResolvedValue(messages);
+  const worker = new BucketExtractWorker(config, bucket, logger);
+  // `update` indexes the (mocked) file then triggers `write`.
+  await worker.update(join(dir, 'src', 'app.ts'));
+}
+
+describe('BucketExtractWorker.write', () => {
+  it('writes the extracted messages to the source locale', async () => {
+    await extract([
+      msg({ message: 'Hello', id: 'greeting' }),
+      msg({ message: 'Bye', id: 'farewell' }),
+    ]);
+
+    expect(readLocale('en').map((m) => m.id)).toEqual(
+      expect.arrayContaining(['greeting', 'farewell']),
+    );
+  });
+
+  it('creates a header-only file for a locale that does not exist yet', async () => {
+    await extract([msg({ message: 'Hello', id: 'greeting' })]);
+
+    expect(readLocale('de')).toEqual([]);
+    expect(existsSync(`${localePath('de')}.d.ts`)).toBe(true);
+  });
+
+  it('leaves an existing non-source locale completely untouched', async () => {
+    const frPath = localePath('fr');
+    mkdirSync(dirname(frPath), { recursive: true });
+    const original = JSON.stringify([
+      { message: 'Old', id: 'orphan', translation: 'Vieux', comments: [], references: [] },
+    ]);
+    writeFileSync(frPath, original);
+
+    await extract([msg({ message: 'Hello', id: 'greeting' })]);
+
+    // No additions, and the orphaned string is not stripped.
+    expect(readFileSync(frPath, 'utf8')).toBe(original);
+  });
+});

--- a/packages/config/src/features/workers/extract-worker.ts
+++ b/packages/config/src/features/workers/extract-worker.ts
@@ -1,10 +1,19 @@
+import { access } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Message } from '~/shapes';
 import { extractMessagesFromFile } from '../catalogue/extractor';
-import { mergeExtractedMessages, reconcileLocaleMessages } from '../catalogue/merge';
-import { readCatalogueMessages, writeCatalogueMessages } from '../catalogue/storage';
+import { mergeExtractedMessages } from '../catalogue/merge';
+import { expandBucketOutputPath } from '../catalogue/path';
+import { writeCatalogueMessages } from '../catalogue/storage';
 import { globBucket, watchDebounced } from '../watch';
 import { BucketWorker, normalisePathForLogs } from './shared';
+
+function exists(path: string) {
+  return access(path).then(
+    () => true,
+    () => false,
+  );
+}
 
 export class BucketExtractWorker extends BucketWorker {
   #indexedMessagesByPath = new Map<string, Message[]>();
@@ -43,18 +52,28 @@ export class BucketExtractWorker extends BucketWorker {
 
   async write() {
     const mergedMessages = mergeExtractedMessages(this.#indexedMessages);
-    this.logger.info(`Writing ${mergedMessages.length} messages to locales`);
+    const [sourceLocale, ...otherLocales] = this.config.locales;
 
-    for (const locale of this.config.locales) {
-      this.logger.step(`Writing locale file for ${locale} to disk`);
+    // Extraction only ever writes the source locale's messages. Non-source
+    // locales are owned by the TMS, so we never add, change, or remove their
+    // strings here — doing so produces huge diffs and destroys orphaned
+    // translations the TMS is responsible for cleaning up.
+    this.logger.info(`Writing ${mergedMessages.length} messages to ${sourceLocale}`);
+    this.logger.step(`Writing locale file for ${sourceLocale} to disk`);
+    await writeCatalogueMessages(this.bucket, sourceLocale, mergedMessages);
 
-      const existingMessages = await readCatalogueMessages(this.bucket, locale);
-      const nextMessages =
-        locale === this.config.locales[0]
-          ? mergedMessages
-          : reconcileLocaleMessages(existingMessages, mergedMessages);
+    // Bootstrap any locale that does not have a file yet with a minimal,
+    // message-less catalogue (just a header) so a TMS like Weblate can register
+    // the locale. Existing non-source files are left completely untouched.
+    for (const locale of otherLocales) {
+      const path = expandBucketOutputPath(this.bucket, locale);
+      if (await exists(path)) {
+        this.logger.step(`Skipping existing locale file for ${locale}`);
+        continue;
+      }
 
-      await writeCatalogueMessages(this.bucket, locale, nextMessages);
+      this.logger.step(`Creating empty locale file for ${locale}`);
+      await writeCatalogueMessages(this.bucket, locale, []);
     }
 
     this.logger.success(`Extraction complete for bucket: ${this.bucket.include}`);

--- a/packages/config/src/shapes.ts
+++ b/packages/config/src/shapes.ts
@@ -59,6 +59,13 @@ export type Bucket = z.infer<typeof Bucket>;
 
 export const Config = z.object({
   locales: z.tuple([z.string()], z.string()),
+  /**
+   * Per-locale fallback chains, most specific first, e.g.
+   * `{ 'en-NZ': ['en-GB'], 'es-MX': 'es' }`. The source locale (the first entry
+   * in {@link Config.locales}) is always appended as the final fallback, so an
+   * untranslated key ultimately resolves to the source string.
+   */
+  fallbackLocales: z.record(z.string(), z.string().or(z.string().array())).optional(),
   buckets: Bucket.array(),
 });
 export type Config = z.infer<typeof Config>;

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: [
     'src/index.ts',
     'src/commands/index.ts',
+    'src/features/catalogue/index.ts',
     'src/features/loader/index.ts',
     'src/features/messages/index.ts',
   ],

--- a/packages/plugin-babel/src/index.test.ts
+++ b/packages/plugin-babel/src/index.test.ts
@@ -5,13 +5,19 @@ import { transformSync } from '@babel/core';
 import { generateHash } from '@saykit/config/features/messages';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 
+const dir = mkdtempSync(join(tmpdir(), 'saykit-babel-'));
+
 const config = {
+  locales: ['en', 'fr'],
   buckets: [
     {
       match: (id: string) => id.endsWith('.ts'),
-      output: { match: (id: string) => id.endsWith('.json') },
+      output: Object.assign(join(dir, '{locale}.{extension}'), {
+        match: (id: string) => id.endsWith('.json'),
+      }),
       transformer: { transform: (code: string) => code.replace('MARK', 'DONE') },
       formatter: {
+        extension: '.json',
         parse: (content: string) =>
           JSON.parse(content) as { message: string; translation?: string; id?: string }[],
       },
@@ -23,7 +29,6 @@ vi.mock('@saykit/config/features/loader', () => ({ resolveConfig: () => config }
 
 const { default: plugin } = await import('./index.js');
 
-const dir = mkdtempSync(join(tmpdir(), 'saykit-babel-'));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
 const run = (code: string, filename: string) =>
@@ -48,9 +53,8 @@ describe('plugin-babel parserOverride', () => {
 
 describe('plugin-babel inline imports', () => {
   it('replaces a default import of a catalogue with an inlined record', () => {
-    const cat = join(dir, 'messages.json');
     writeFileSync(
-      cat,
+      join(dir, 'messages.json'),
       JSON.stringify([
         { message: 'Hello', translation: 'Bonjour', id: 'greeting' },
         { message: 'Bye', translation: '' },
@@ -61,6 +65,24 @@ describe('plugin-babel inline imports', () => {
     expect(out).toContain('Bonjour');
     // No id + empty translation -> hashed key with the source text.
     expect(out).toContain(generateHash('Bye', undefined));
+  });
+
+  it('falls back to the source locale for keys untranslated in a non-source locale', () => {
+    writeFileSync(
+      join(dir, 'en.json'),
+      JSON.stringify([
+        { message: 'Hello', id: 'greeting' },
+        { message: 'Bye', id: 'farewell' },
+      ]),
+    );
+    writeFileSync(
+      join(dir, 'fr.json'),
+      JSON.stringify([{ message: 'Hello', translation: 'Bonjour', id: 'greeting' }]),
+    );
+
+    const out = run(`import m from './fr.json';\nexport default m;`, join(dir, 'app.ts'));
+    expect(out).toContain('Bonjour'); // real translation
+    expect(out).toContain('Bye'); // untranslated -> source fallback
   });
 
   it('ignores bare (non-relative) imports', () => {

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { types as t, type PluginObj, type PluginAPI, type parse as Parse } from '@babel/core';
+import {
+  assembleCatalogueRecord,
+  resolveCatalogueSources,
+} from '@saykit/config/features/catalogue';
 import { resolveConfig } from '@saykit/config/features/loader';
-import { generateHash } from '@saykit/config/features/messages';
 
 declare module '@babel/core' {
   interface PluginAPI {
@@ -47,15 +50,24 @@ export default (api: PluginAPI): PluginObj => {
         if (!specifier)
           throw path.buildCodeFrameError('SayKit inline imports require a default import');
 
-        const content = readFileSync(id, 'utf8');
-        try {
-          api.addExternalDependency(id_);
-        } catch {}
+        // Merge the fallback chain (configured fallbacks + the source locale)
+        // so untranslated keys resolve to a fallback string at build time.
+        const { sources } = resolveCatalogueSources(config, bucket, id);
+        const contents = sources.map((source) => {
+          try {
+            return readFileSync(source, 'utf8');
+          } catch {
+            return '';
+          }
+        });
 
-        const messages = bucket.formatter.parse(content);
-        const entries = messages.map(
-          (m) => [m.id || generateHash(m.message, m.context), m.translation || m.message] as const,
-        );
+        for (const source of sources) {
+          try {
+            api.addExternalDependency(source);
+          } catch {}
+        }
+
+        const entries = Object.entries(assembleCatalogueRecord(bucket, contents));
 
         path.replaceWith(
           t.variableDeclaration('const', [

--- a/packages/plugin-unplugin/src/index.test.ts
+++ b/packages/plugin-unplugin/src/index.test.ts
@@ -1,16 +1,23 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { generateHash } from '@saykit/config/features/messages';
 import { afterAll, describe, expect, it, vi } from 'vitest';
 
+const dir = mkdtempSync(join(tmpdir(), 'saykit-unplugin-'));
+
 const config = {
+  locales: ['en', 'en-GB', 'en-NZ', 'fr'],
+  fallbackLocales: { 'en-NZ': ['en-GB'] },
   buckets: [
     {
       match: (id: string) => id.endsWith('.ts'),
-      output: { match: (id: string) => id.endsWith('messages.json') },
+      output: Object.assign(join(dir, '{locale}', 'messages.{extension}'), {
+        match: (id: string) => id.endsWith('messages.json'),
+      }),
       transformer: { transform: (code: string) => code.replace('say', 'SAY') },
       formatter: {
+        extension: '.json',
         parse: (content: string) =>
           JSON.parse(content) as {
             message: string;
@@ -31,8 +38,16 @@ const plugin = unplugin.raw(undefined, { framework: 'rollup' } as never) as {
   load: { handler: (id: string) => Promise<string | undefined> };
 };
 
-const dir = mkdtempSync(join(tmpdir(), 'saykit-unplugin-'));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+const write = (locale: string, content: unknown) => {
+  const file = join(dir, locale, 'messages.json');
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, typeof content === 'string' ? content : JSON.stringify(content));
+  return file;
+};
+
+const record = (output: string | undefined) => JSON.parse(output!.replace('export default ', ''));
 
 describe('unplugin transform', () => {
   it('transforms code for a matching bucket', () => {
@@ -45,22 +60,56 @@ describe('unplugin transform', () => {
 });
 
 describe('unplugin load', () => {
-  it('loads a catalogue file into a default-exported record', async () => {
-    const file = join(dir, 'messages.json');
-    writeFileSync(
-      file,
-      JSON.stringify([
-        { message: 'Hello', translation: 'Bonjour', id: 'greeting' },
-        { message: 'Bye', translation: '' },
-      ]),
-    );
+  it('loads the source locale into a default-exported record', async () => {
+    const file = write('en', [
+      { message: 'Hello', translation: '', id: 'greeting' },
+      { message: 'Bye', translation: '' },
+    ]);
 
     const output = await plugin.load.handler(file);
     expect(output).toContain('export default');
-    const record = JSON.parse(output!.replace('export default ', ''));
-    expect(record.greeting).toBe('Bonjour');
+    const messages = record(output);
+    expect(messages.greeting).toBe('Hello');
     // No id and empty translation -> hashed key, source text as value.
-    expect(record[generateHash('Bye', undefined)]).toBe('Bye');
+    expect(messages[generateHash('Bye', undefined)]).toBe('Bye');
+  });
+
+  it('falls back to the source string for keys untranslated in a non-source locale', async () => {
+    write('en', [
+      { message: 'Hello', id: 'greeting' },
+      { message: 'Bye', id: 'farewell' },
+    ]);
+    const file = write('fr', [{ message: 'Hello', translation: 'Bonjour', id: 'greeting' }]);
+
+    const messages = record(await plugin.load.handler(file));
+    expect(messages.greeting).toBe('Bonjour'); // real translation wins
+    expect(messages.farewell).toBe('Bye'); // untranslated -> source fallback
+  });
+
+  it('resolves an empty non-source locale entirely to source strings', async () => {
+    write('en', [{ message: 'Hello', id: 'greeting' }]);
+    const file = write('fr', '');
+
+    const messages = record(await plugin.load.handler(file));
+    expect(messages.greeting).toBe('Hello');
+  });
+
+  it('resolves a configured fallback chain before the source locale', async () => {
+    write('en', [
+      { message: 'A', id: 'a' },
+      { message: 'B', id: 'b' },
+      { message: 'C', id: 'c' },
+    ]);
+    write('en-GB', [
+      { message: 'B', translation: 'B-GB', id: 'b' },
+      { message: 'C', translation: 'C-GB', id: 'c' },
+    ]);
+    const file = write('en-NZ', [{ message: 'C', translation: 'C-NZ', id: 'c' }]);
+
+    const messages = record(await plugin.load.handler(file));
+    expect(messages.a).toBe('A'); // only in the source
+    expect(messages.b).toBe('B-GB'); // from the en-GB fallback
+    expect(messages.c).toBe('C-NZ'); // en-NZ wins over en-GB and the source
   });
 
   it('returns undefined when the id does not match a bucket output', async () => {

--- a/packages/plugin-unplugin/src/index.ts
+++ b/packages/plugin-unplugin/src/index.ts
@@ -1,8 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import { relative } from 'node:path';
+import {
+  assembleCatalogueRecord,
+  resolveCatalogueSources,
+} from '@saykit/config/features/catalogue';
 import { resolveConfig } from '@saykit/config/features/loader';
-import { generateHash } from '@saykit/config/features/messages';
-import { createUnplugin } from 'unplugin';
+import { createUnplugin, type UnpluginBuildContext } from 'unplugin';
 
 export default createUnplugin((_options?: never) => {
   const config = resolveConfig();
@@ -23,18 +26,24 @@ export default createUnplugin((_options?: never) => {
     load: {
       // TODO: Can bucket output be used in this filter?
       filter: { id: { exclude: /node_modules/ } },
-      handler: async (id_) => {
+      handler: async function (this: UnpluginBuildContext, id_: string) {
         const id = relative(process.cwd(), id_).replaceAll('\\', '/').split('?')[0]!;
         const bucket = config.buckets.find((b) => b.output.match(id));
         if (!bucket) return;
 
-        const content = await readFile(id, 'utf8');
-        const messages = bucket.formatter.parse(content);
-        const entries = messages.map(
-          (m) => [m.id || generateHash(m.message, m.context), m.translation || m.message] as const,
+        // The fallback chain (configured fallbacks + the source locale) is
+        // merged in here at load time so an untranslated key resolves to a
+        // fallback string while the runtime still loads a single locale module.
+        const { sources } = resolveCatalogueSources(config, bucket, id);
+        const contents = await Promise.all(
+          sources.map((source) => readFile(source, 'utf8').catch(() => '')),
         );
 
-        return `export default ${JSON.stringify(Object.fromEntries(entries))}`;
+        // Fallback files feed this module, so editing them should invalidate it.
+        for (const source of sources) this.addWatchFile?.(source);
+
+        const record = assembleCatalogueRecord(bucket, contents);
+        return `export default ${JSON.stringify(record)}`;
       },
     },
   };

--- a/website/content/core-concepts/architecture.mdx
+++ b/website/content/core-concepts/architecture.mdx
@@ -56,7 +56,7 @@ Two distinct workflows share the same config:
 └──────────────┘    └────────────┘    └──────────────┘
 ```
 
-The CLI reads `saykit.config.ts`, walks the bucket globs, asks each transformer to extract messages, and asks the formatter to write them to disk. New runs reconcile against existing files, your translations are never overwritten.
+The CLI reads `saykit.config.ts`, walks the bucket globs, asks each transformer to extract messages, and asks the formatter to write the **source** locale to disk. Other locale files are never touched by extraction (`saykit clean` reconciles them on demand), so your translations are never overwritten.
 
 ### Build (your bundler runs this)
 
@@ -188,6 +188,6 @@ Translation catalogues are emitted as plain JS modules, tree-shakable, code-spli
   <Card
     title="Extraction"
     href="/core-concepts/extraction"
-    description="The CLI, watch mode, reconciliation."
+    description="The CLI, watch mode, source-only writes, fallback."
   />
 </Cards>

--- a/website/content/core-concepts/configuration.mdx
+++ b/website/content/core-concepts/configuration.mdx
@@ -24,7 +24,7 @@ export default defineConfig({
 });
 ```
 
-The first locale in `locales` is treated as the **source locale**: the language your code is written in, and the one extraction writes through as-is. Other locales are reconciled against it on every run. The config is validated by Zod at load time, mistakes get caught with a clear error.
+The first locale in `locales` is treated as the **source locale**: the language your code is written in, and the only one extraction writes to. Other locale files are left to your translation management system; untranslated keys resolve through a [fallback chain](#fallback-locales) at load time. The config is validated by Zod at load time, mistakes get caught with a clear error.
 
 <Callout type="info">
   `defineConfig()` doesn't just type the config, it also runs it through the Zod schema and returns
@@ -54,9 +54,14 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
       type: '[string, ...string[]]',
       required: true,
     },
+    fallbackLocales: {
+      description:
+        'Per-locale fallback chains, most specific first. The source locale is always appended as the final fallback.',
+      type: 'Record<string, string | string[]>',
+    },
     buckets: {
       description:
-        'One or more extraction buckets. Each bucket scans a set of files and writes one translation file per locale.',
+        'One or more extraction buckets. Each bucket scans a set of files and writes the source-locale translation file.',
       type: 'Bucket[]',
       required: true,
     },
@@ -76,6 +81,31 @@ The **source locale** is whichever entry you list first. It's the locale your co
 <Callout type="warn">
   Reordering `locales` so that a different entry sits first means SayKit will treat your existing
   source messages as if they were in the new source locale. Plan this early.
+</Callout>
+
+## Fallback locales
+
+Because [extraction](/core-concepts/extraction) only writes the source locale, non-source catalogues carry just their real translations. A key that hasn't been translated in a locale is resolved through a **fallback chain** when the build plugin loads the catalogue.
+
+By default every locale falls back straight to the source. `fallbackLocales` lets you insert intermediate locales first, most specific first:
+
+```ts title="saykit.config.ts"
+export default defineConfig({
+  locales: ['en', 'en-GB', 'en-NZ', 'es-MX', 'es'],
+  fallbackLocales: {
+    'en-NZ': ['en-GB'], // en-NZ → en-GB → en (source)
+    'es-MX': 'es', // es-MX → es → en (source)
+  },
+  buckets: [/* … */],
+});
+```
+
+A single fallback can be a bare string; multiple fallbacks are an array. SayKit always appends the source locale as the final entry, so an untranslated key ultimately renders the source string, no locale ever resolves to a missing message.
+
+<Callout type="info">
+  The chain is resolved and baked into the emitted JS at build time, so the runtime still loads a
+  single locale. Nothing about fallbacks reaches `Say`. See
+  [Extraction → fallback at load time](/core-concepts/extraction#fallback-at-load-time).
 </Callout>
 
 ## Buckets
@@ -201,5 +231,5 @@ export default defineConfig({
 ## Next
 
 - [Messages](/core-concepts/messages), what you can author
-- [Extraction](/core-concepts/extraction), running the CLI, watch mode, reconciliation
+- [Extraction](/core-concepts/extraction), running the CLI, watch mode, source-only writes
 - [Formats](/core-concepts/formats), PO and writing your own

--- a/website/content/core-concepts/extraction.mdx
+++ b/website/content/core-concepts/extraction.mdx
@@ -3,7 +3,7 @@ title: Extraction
 description: How the saykit CLI scans your source and produces translation files
 ---
 
-The `saykit` CLI scans your source files for macros, normalises them to ICU MessageFormat, and writes one translation file per locale per bucket. It's the only SayKit tool that touches your disk, the runtime never does.
+The `saykit` CLI scans your source files for macros, normalises them to ICU MessageFormat, and writes the source-locale translation file for each bucket. It's the only SayKit tool that touches your disk, the runtime never does.
 
 ```sh
 pnpm saykit extract
@@ -17,7 +17,7 @@ For each bucket in your config the CLI:
 2. **Asks each transformer** to parse each file and extract messages.
 3. **Merges and de-duplicates** messages across files. Identical text + context get one entry with all source references combined.
 4. **Hashes** each message into a 6-character id (unless you provided a custom one in a descriptor).
-5. **Writes** one catalogue file per locale via the bucket's formatter.
+5. **Writes** the **source** locale catalogue via the bucket's formatter, and creates an empty placeholder file for any locale that doesn't have one yet.
 
 The end result is a set of files like:
 
@@ -25,7 +25,7 @@ The end result is a set of files like:
 src/locales/
   en.po         # source locale, freshly generated from your source
   en.po.d.ts    # auto-generated TS declaration for *.po imports
-  fr.po         # other locales, reconciled with the source, your translations preserved
+  fr.po         # other locales, left untouched (or created empty if missing)
   fr.po.d.ts
 ```
 
@@ -34,18 +34,32 @@ src/locales/
   type-checks even without a build plugin running. See [typed messages](/guides/typed-messages).
 </Callout>
 
-## Reconciliation
+## Source-only writes
 
-The first run writes both source and target locale files from scratch.
+Extraction writes **only** the source locale (the first entry in `locales`). It never edits your other locale files.
 
-Subsequent runs treat the source locale as the truth, and reconcile each target locale against it:
+- The source catalogue is regenerated from your code on every run.
+- A locale that has **no file yet** is bootstrapped with an empty, header-only catalogue so a TMS like Weblate can register it.
+- Locales that **already have a file** are left completely untouched, no keys added, none removed.
 
-- New source messages get added to every target locale, with an empty `msgstr`.
-- Source messages that no longer exist get dropped from target locales.
-- Translations for messages that still exist are **preserved**.
-- The target file's headers (PO `Language:`, etc.) are kept across runs.
+This keeps diffs small (changing one string touches one file) and treats translated content as owned by your translation management system, not by extraction. You can run `saykit extract` as often as you like; your translators' work is never touched.
 
-You can run `saykit extract` as often as you like, your translators' work is never overwritten.
+### Fallback at load time
+
+Because non-source files no longer carry the source strings, an untranslated (or missing) key is resolved through a **fallback chain** when the build plugin loads a catalogue, not at runtime. By default the chain ends at the source locale, so an untranslated key renders the source string. You can insert intermediate locales with [`fallbackLocales`](/core-concepts/configuration#fallback-locales):
+
+```ts title="saykit.config.ts"
+fallbackLocales: {
+  'en-NZ': ['en-GB'], // en-NZ → en-GB → en (source)
+  'es-MX': 'es',      // es-MX → es → en (source)
+},
+```
+
+The chain is baked into the emitted JS module at build time, so the runtime still loads a single locale. See [Vite](/integrations/vite) / [Babel](/integrations/babel) for how loading works.
+
+### Reconciling other locales yourself
+
+If you'd rather propagate source changes into your other locale files directly (instead of leaving it to a TMS), run [`saykit clean`](/reference/cli#saykit-clean). It reconciles every non-source locale against the current source catalogue: adds missing keys (untranslated), drops keys that no longer exist in the source, and preserves existing translations.
 
 ## Watch mode
 
@@ -74,9 +88,9 @@ A normal run looks like:
   Scanning bucket: src/**/*.{ts,tsx}
     Found 42 file(s)
   Total extracted messages: 137
-  Writing 137 messages to locales
+  Writing 137 messages to en
     Writing locale file for en to disk
-    Writing locale file for fr to disk
+    Skipping existing locale file for fr
   ✓ Extraction complete for bucket: src/**/*.{ts,tsx}
 ```
 

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -306,5 +306,5 @@ say`Hello, ` + name; // ✗
 ## Next
 
 - [Runtime](/core-concepts/runtime), loading and activating locales, formatting at runtime
-- [Extraction](/core-concepts/extraction), running the CLI, watch mode, reconciliation
+- [Extraction](/core-concepts/extraction), running the CLI, watch mode, source-only writes
 - [React](/integrations/react), `<Say>` in detail

--- a/website/content/getting-started/quickstart.mdx
+++ b/website/content/getting-started/quickstart.mdx
@@ -116,9 +116,11 @@ SayKit walks your source, finds every macro, and writes the catalogue files:
 src/locales/
   en.po         # source locale, generated from your source
   en.po.d.ts    # auto-generated TS declaration
-  fr.po         # other locales, ready for translation
+  fr.po         # other locales, created empty (header only)
   fr.po.d.ts
 ```
+
+Extraction only writes the **source** locale (`en`). Other locales are created empty the first time and then left untouched, translated content is owned by your translation management system, and untranslated keys fall back to the source string automatically. See [extraction](/core-concepts/extraction) for the full picture.
 
 For iterative development, use watch mode:
 
@@ -141,7 +143,13 @@ msgstr "Add one"
 
 ## 6. Translate
 
-Open `fr.po` and fill in `msgstr` for each entry:
+Your `fr.po` starts empty. If you manage translations by hand rather than through a TMS, seed it with the source keys using `saykit clean`:
+
+```sh
+pnpm saykit clean
+```
+
+Then open `fr.po` and fill in `msgstr` for each entry:
 
 ```po title="src/locales/fr.po"
 msgid "Hello, {name}!"
@@ -151,7 +159,7 @@ msgid "Add one"
 msgstr "Ajouter un"
 ```
 
-Future `extract` runs reconcile new and removed messages without overwriting your translations.
+`extract` only ever writes the source locale, so your translations are never touched. Run `saykit clean` again whenever you want to pull new source keys into your locale files and drop removed ones, existing translations are preserved. Any key you leave untranslated falls back to the source string.
 
 ## 7. Provide a `Say` at runtime
 

--- a/website/content/integrations/babel.mdx
+++ b/website/content/integrations/babel.mdx
@@ -76,9 +76,9 @@ module.exports = function (api) {
 For every non-`node_modules` source file passed through Babel, the plugin:
 
 1. Runs the matching SayKit transformer over the source, rewriting macros to `say.call(...)` invocations.
-2. Watches for static imports of translation files (e.g. `import en from './locales/en.po'`), parses them with the bucket's formatter, and inlines the catalogue as a JS object literal in place of the import.
+2. Watches for static imports of translation files (e.g. `import fr from './locales/fr.po'`), resolves that locale's [fallback chain](/core-concepts/configuration#fallback-locales), parses each file in it with the bucket's formatter, and inlines the merged catalogue as a JS object literal in place of the import, untranslated keys falling back through the chain to the source string.
 
-The result: no `.po` file at runtime, no SayKit extractor in the bundle, just small `say.call()` calls and plain JS objects.
+The result: no `.po` file at runtime, no SayKit extractor in the bundle, just small `say.call()` calls and plain JS objects, one locale per module. Each file in the chain is registered as an external dependency so Babel re-runs when the source locale changes.
 
 <Callout type="warn">
   The plugin currently only rewrites **static** imports. `import('./locales/en.po')` (dynamic

--- a/website/content/integrations/vite.mdx
+++ b/website/content/integrations/vite.mdx
@@ -122,7 +122,7 @@ The plugin takes no options, everything it needs lives in your `saykit.config.ts
 
 For every file in your bucket's `include` globs, the plugin asks the configured transformers to rewrite the source. Macros like `` say`Hello, ${name}!` `` become small `say.call({ id: '...', name })` runtime invocations.
 
-For every import that matches a bucket's `output` template, e.g. `import en from './locales/en.po'`, the plugin parses the file with the bucket's formatter and emits a JS module exporting the compiled catalogue. There is no `.po` file at runtime; just plain JS objects.
+For every import that matches a bucket's `output` template, e.g. `import fr from './locales/fr.po'`, the plugin resolves that locale's [fallback chain](/core-concepts/configuration#fallback-locales), parses each file in it with the bucket's formatter, and emits a single JS module exporting the merged catalogue, real translations overlaying their fallbacks, untranslated keys resolving to the source string. There is no `.po` file at runtime; just plain JS objects, and still only one locale per module. Each source file in the chain is registered as a watch dependency, so editing the source locale re-runs the load for dependent locales in dev.
 
 ## Plugin ordering
 

--- a/website/content/reference/api/config.mdx
+++ b/website/content/reference/api/config.mdx
@@ -50,6 +50,11 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
       type: '[string, ...string[]]',
       required: true,
     },
+    fallbackLocales: {
+      description:
+        'Per-locale fallback chains, most specific first. The source locale is always appended as the final fallback, resolved at load time. See the configuration guide.',
+      type: 'Record<string, string | string[]>',
+    },
     buckets: {
       description: 'Extraction buckets.',
       type: 'Bucket[]',
@@ -219,6 +224,26 @@ The internal `Message` types used by transformers (different from the public cat
 - `assignSequenceIdentifiers(message, { current: 0 })`, numbers positional placeholders depth-first
 
 These exist so that custom transformers can produce the same id and placeholder shape the built-in transformers do.
+
+### `@saykit/config/features/catalogue`
+
+```ts
+import {
+  expandBucketOutputPath,
+  resolveFallbackChain,
+  resolveCatalogueSources,
+  assembleCatalogueRecord,
+  reconcileLocaleMessages,
+} from '@saykit/config/features/catalogue';
+```
+
+Catalogue path and fallback helpers shared by the build plugins. Most apps never import these directly, they're what `unplugin-saykit` and `babel-plugin-saykit` use to resolve a locale's [fallback chain](/core-concepts/configuration#fallback-locales) and inline the merged record at build time.
+
+- `expandBucketOutputPath(bucket, locale)`, the concrete output path for a locale.
+- `resolveFallbackChain(config, locale)`, the ordered list of locales to try, ending at the source.
+- `resolveCatalogueSources(config, bucket, id)`, resolves an imported catalogue path to its `{ locale, sources }` (fallback files, most specific first).
+- `assembleCatalogueRecord(bucket, contents)`, merges parsed catalogue contents into a single `id → string` record, most specific winning.
+- `reconcileLocaleMessages(existing, source)`, the reconciliation used by `saykit clean`.
 
 ## Next
 

--- a/website/content/reference/cli.mdx
+++ b/website/content/reference/cli.mdx
@@ -3,7 +3,7 @@ title: CLI
 description: The saykit command-line interface, every command and flag
 ---
 
-The `saykit` CLI extracts messages from your source files. It's installed with `@saykit/config` and exposes one command today: `extract`.
+The `saykit` CLI extracts messages from your source files. It's installed with `@saykit/config` and exposes two commands: `extract` and `clean`.
 
 ```sh
 saykit --help
@@ -12,7 +12,7 @@ saykit help [command]
 
 ## `saykit extract`
 
-Walk every bucket in `saykit.config.ts`, extract messages from the files matched by `include`, and write catalogue files per locale.
+Walk every bucket in `saykit.config.ts`, extract messages from the files matched by `include`, and write the **source** locale catalogue. Other locales are never edited; a locale with no file yet is created empty so a TMS can register it.
 
 ```sh
 saykit extract
@@ -54,9 +54,8 @@ For each bucket:
 2. Asks each transformer to parse each file and return a list of messages.
 3. Merges entries with the same text + context, unioning their references.
 4. Hashes ids for messages without a custom id.
-5. Reconciles target locales against the source, preserving existing translations, adding new entries, removing stale ones.
-6. Writes one catalogue file per locale via the bucket's formatter.
-7. Writes a `.d.ts` declaration next to each catalogue.
+5. Writes the **source** locale catalogue via the bucket's formatter, and creates an empty placeholder for any locale that has no file yet. Existing non-source files are left untouched.
+6. Writes a `.d.ts` declaration next to each catalogue.
 
 ### Exit codes
 
@@ -66,6 +65,45 @@ For each bucket:
 | 1    | Failure during config load, extraction, or write. |
 
 The CLI throws on unrecoverable errors (missing config, invalid config, formatter parse failure). Use `--verbose` to see the full stack.
+
+## `saykit clean`
+
+Reconcile every non-source locale file against the current source catalogue. Since `extract` only writes the source locale, `clean` is how you propagate source changes into your other locale files yourself, rather than leaving it to a translation management system.
+
+```sh
+saykit clean
+saykit clean --verbose
+saykit clean --quiet
+```
+
+For each bucket, and each locale after the source, `clean`:
+
+- **adds** keys present in the source but missing from the locale, with an empty translation,
+- **drops** keys that no longer exist in the source,
+- **preserves** existing translations for keys that still exist,
+- refreshes the source-of-truth fields (message text, context, comments, references) from the source.
+
+### Options
+
+<TypeTable
+  type={{
+    '--verbose, -v': {
+      description: 'Print per-locale step logs in addition to summaries.',
+      type: 'boolean',
+      default: 'false',
+    },
+    '--quiet, -q': {
+      description: 'Suppress all logging.',
+      type: 'boolean',
+      default: 'false',
+    },
+  }}
+/>
+
+<Callout type="info">
+  `clean` is optional. If your TMS already manages orphaned keys and untranslated entries, you may
+  never need it, extraction plus load-time fallback is enough on its own.
+</Callout>
 
 ## Configuration discovery
 
@@ -110,4 +148,4 @@ This fails the build if anyone forgot to run `extract` after changing or adding 
 
 ## Future commands
 
-The CLI is intentionally tiny today. New commands (compile, lint, stats) may land before 1.0. Anything published outside `extract` will go through the same `saykit <command> --help` discovery.
+The CLI is intentionally small today. New commands (compile, lint, stats) may land before 1.0. Anything published outside `extract` and `clean` will go through the same `saykit <command> --help` discovery.


### PR DESCRIPTION
Closes #34 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `saykit clean` command to reconcile non-source locale files while preserving existing translations.
  * Added configurable per-locale fallback chains, ensuring missing translations fall back to appropriate locales and source text.
  * Extraction now writes only the source locale and creates placeholders for missing locale files.
  * Build integrations now merge locale catalogues using fallback chains.

* **Documentation**
  * Updated CLI, configuration, integration, API, and quickstart guides to explain source-only extraction, fallback behaviour, and cleanup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->