### PR TITLE
Add @saykit/format-json JSON output formatter

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,6 +6,7 @@
     ["saykit", "@saykit/carbon", "@saykit/react"],
     [
       "@saykit/config",
+      "@saykit/format-json",
       "@saykit/format-po",
       "babel-plugin-saykit",
       "unplugin-saykit",

--- a/.changeset/format-json.md
+++ b/.changeset/format-json.md
@@ -1,0 +1,7 @@
+---
+"@saykit/format-json": minor
+---
+
+Add `@saykit/format-json`, a JSON catalogue formatter.
+
+Writes one pretty-printed, flat JSON file per locale, keyed by message id, for projects that want plain JSON i18n bundles without any Gettext tooling. An optional `dialect` option (`'arb'` or `'webextension'`) switches to a richer layout that preserves comments, context, and source references.

--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -30,6 +30,10 @@
   - changed-files:
       - any-glob-to-any-file: ['packages/config/**']
 
+'package: format-json':
+  - changed-files:
+      - any-glob-to-any-file: ['packages/format-json/**']
+
 'package: format-po':
   - changed-files:
       - any-glob-to-any-file: ['packages/format-po/**']

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -44,6 +44,10 @@
   description: Related to @saykit/config and the CLI
   color: f97316
 
+- name: 'package: format-json'
+  description: Related to @saykit/format-json
+  color: eab308
+
 - name: 'package: format-po'
   description: Related to @saykit/format-po
   color: 84cc16

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,6 +21,9 @@ flags:
   config:
     paths:
       - packages/config/
+  format-json:
+    paths:
+      - packages/format-json/
   format-po:
     paths:
       - packages/format-po/
@@ -60,6 +63,9 @@ component_management:
     - component_id: config
       name: config
       paths: [packages/config/**]
+    - component_id: format-json
+      name: format-json
+      paths: [packages/format-json/**]
     - component_id: format-po
       name: format-po
       paths: [packages/format-po/**]

--- a/packages/format-json/README.md
+++ b/packages/format-json/README.md
@@ -1,0 +1,80 @@
+# @saykit/format-json
+
+> JSON file formatter for [SayKit](https://saykit.js.org).
+
+[![Coverage](https://codecov.io/gh/k0d13/saykit/graph/badge.svg?flag=format-json)](https://codecov.io/gh/k0d13/saykit?flags%5B0%5D=format-json)
+
+Writes one JSON catalogue per locale — the de facto format for web i18n
+(react-intl, FormatJS, i18next, …). Reach for this instead of
+[`@saykit/format-po`](https://github.com/k0d13/saykit/tree/main/packages/format-po)
+when you want plain JSON bundles with no Gettext tooling.
+
+## Install
+
+```sh
+pnpm add -D @saykit/format-json
+```
+
+## Usage
+
+```ts title="saykit.config.ts"
+import json from '@saykit/format-json';
+
+// inside a bucket:
+formatter: json();
+```
+
+Each catalogue is a pretty-printed, flat map keyed by the message id (falling
+back to a stable content hash when a message has no id — the same key the
+runtime resolves), with the translation as the value:
+
+```json
+{
+  "greeting": "Hello"
+}
+```
+
+ICU MessageFormat strings are stored verbatim as JSON string values — JSON
+escaping is handled for you.
+
+### Dialects
+
+The plain layout above is just `{ key: value }`, so it drops comments, context,
+and source references. Pass `dialect` to keep them using a richer — but still
+standard — JSON layout:
+
+- `dialect: 'arb'` — [Application Resource Bundle](https://github.com/google/app-resource-bundle)
+  (Flutter/Dart `intl`). Strings stay flat; each key's metadata lives in a
+  sibling `@key` object.
+- `dialect: 'webextension'` — the Chrome/WebExtension `messages.json` shape,
+  where each key maps to a `{ message, description }` object.
+
+```ts
+formatter: json({ dialect: 'arb' });
+```
+
+```json title="ARB"
+{
+  "@@locale": "fr",
+  "greeting": "Bonjour",
+  "@greeting": {
+    "description": "A friendly hello",
+    "x-saykit-context": "formal",
+    "x-saykit-references": ["src/app.ts:10"]
+  }
+}
+```
+
+Both formats carry translator comments in their native `description` field.
+Context and source references have no standard slot, so SayKit round-trips them
+through `x-saykit-context` / `x-saykit-references` extension fields — other
+tooling reads the `description` and safely ignores the rest.
+
+> [!NOTE]
+> JSON catalogues are keyed by message id, so give your messages explicit ids to
+> get stable, human-readable keys. Unlike the PO formatter, JSON does not carry
+> source references, comments, or contexts — it is a lean runtime format.
+
+## Documentation
+
+See [saykit.js.org/core-concepts/formats](https://saykit.js.org/core-concepts/formats).

--- a/packages/format-json/package.json
+++ b/packages/format-json/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@saykit/format-json",
+  "version": "0.2.0",
+  "description": "JSON file formatter for saykit",
+  "keywords": [
+    "formatter",
+    "i18n",
+    "json",
+    "saykit"
+  ],
+  "homepage": "https://github.com/k0d13/saykit#readme",
+  "bugs": {
+    "url": "https://github.com/k0d13/saykit/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/k0d13/saykit.git",
+    "directory": "packages/format-json"
+  },
+  "files": [
+    "dist",
+    "!dist/**/*.map"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/formatter.d.mts",
+      "default": "./dist/formatter.mjs"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "build": "tsdown",
+    "prepack": "pnpm build"
+  },
+  "devDependencies": {
+    "@saykit/config": "workspace:^"
+  },
+  "peerDependencies": {
+    "@saykit/config": "*"
+  }
+}

--- a/packages/format-json/src/__fixtures__/messages.arb.json
+++ b/packages/format-json/src/__fixtures__/messages.arb.json
@@ -1,0 +1,10 @@
+{
+  "@@locale": "fr",
+  "farewell": "Au revoir",
+  "greeting": "Bonjour",
+  "@greeting": {
+    "description": "A friendly hello",
+    "x-saykit-context": "formal",
+    "x-saykit-references": ["src/app.ts:10"]
+  }
+}

--- a/packages/format-json/src/__fixtures__/messages.json
+++ b/packages/format-json/src/__fixtures__/messages.json
@@ -1,0 +1,4 @@
+{
+  "farewell": "Au revoir",
+  "greeting": "Bonjour"
+}

--- a/packages/format-json/src/__fixtures__/messages.webext.json
+++ b/packages/format-json/src/__fixtures__/messages.webext.json
@@ -1,0 +1,11 @@
+{
+  "farewell": {
+    "message": "Au revoir"
+  },
+  "greeting": {
+    "message": "Bonjour",
+    "description": "A friendly hello",
+    "x-saykit-context": "formal",
+    "x-saykit-references": ["src/app.ts:10"]
+  }
+}

--- a/packages/format-json/src/formatter.test.ts
+++ b/packages/format-json/src/formatter.test.ts
@@ -1,0 +1,229 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { generateHash } from '@saykit/config/features/messages';
+import { describe, expect, it } from 'vitest';
+import createJsonFormatter from './formatter.js';
+
+const fixture = (name: string) =>
+  readFileSync(join(import.meta.dirname, '__fixtures__', name), 'utf8');
+
+describe('createJsonFormatter', () => {
+  it('uses the .json extension', () => {
+    expect(createJsonFormatter().extension).toBe('.json');
+  });
+
+  describe('parse', () => {
+    const messages = createJsonFormatter().parse(fixture('messages.json'));
+
+    it('reads every entry from the file', () => {
+      expect(messages).toHaveLength(2);
+    });
+
+    it('uses the key as the id and the value as message and translation', () => {
+      const greeting = messages.find((m) => m.id === 'greeting')!;
+      expect(greeting.message).toBe('Bonjour');
+      expect(greeting.translation).toBe('Bonjour');
+      expect(greeting.comments).toEqual([]);
+      expect(greeting.references).toEqual([]);
+    });
+
+    it('ignores non-string values', () => {
+      const parsed = createJsonFormatter().parse('{"a":"x","b":123,"c":null}');
+      expect(parsed.map((m) => m.id)).toEqual(['a']);
+    });
+  });
+
+  describe('stringify', () => {
+    const message = {
+      id: 'greeting',
+      message: 'Hello',
+      translation: 'Bonjour',
+      comments: [],
+      references: [],
+    };
+
+    it('writes a pretty-printed flat object keyed by id, with a trailing newline', () => {
+      const out = createJsonFormatter().stringify([message], { locale: 'fr' });
+      expect(out).toBe('{\n  "greeting": "Bonjour"\n}\n');
+    });
+
+    it('falls back to a content hash for the key when there is no id', () => {
+      const out = createJsonFormatter().stringify(
+        [{ message: 'Hello', translation: 'Bonjour', comments: [], references: [] }],
+        { locale: 'fr' },
+      );
+      expect(JSON.parse(out)).toEqual({ [generateHash('Hello')]: 'Bonjour' });
+    });
+
+    it('hashes message and context together, keeping same text under different contexts distinct', () => {
+      const out = createJsonFormatter().stringify(
+        [
+          {
+            message: 'Post',
+            translation: 'Publier',
+            context: 'verb',
+            comments: [],
+            references: [],
+          },
+          {
+            message: 'Post',
+            translation: 'Article',
+            context: 'noun',
+            comments: [],
+            references: [],
+          },
+        ],
+        { locale: 'fr' },
+      );
+      expect(JSON.parse(out)).toEqual({
+        [generateHash('Post', 'verb')]: 'Publier',
+        [generateHash('Post', 'noun')]: 'Article',
+      });
+    });
+
+    it('defaults the value to an empty string', () => {
+      const out = createJsonFormatter().stringify(
+        [{ message: 'Hi', comments: [], references: [] }],
+        {
+          locale: 'de',
+        },
+      );
+      expect(JSON.parse(out)).toEqual({ [generateHash('Hi')]: '' });
+    });
+
+    it('sorts keys for stable output', () => {
+      const out = createJsonFormatter().stringify(
+        [
+          { id: 'banana', message: 'Banana', translation: 'Banane', comments: [], references: [] },
+          { id: 'apple', message: 'Apple', translation: 'Pomme', comments: [], references: [] },
+        ],
+        { locale: 'fr' },
+      );
+      expect(out.indexOf('apple')).toBeLessThan(out.indexOf('banana'));
+    });
+
+    it('preserves ICU MessageFormat strings as JSON string values', () => {
+      const icu = '{count, plural, one {# item} other {# items}}';
+      const out = createJsonFormatter().stringify(
+        [{ id: 'items', message: icu, translation: icu, comments: [], references: [] }],
+        { locale: 'en' },
+      );
+      expect(JSON.parse(out).items).toBe(icu);
+    });
+
+    it('round-trips through parse', () => {
+      const formatter = createJsonFormatter();
+      const out = formatter.stringify([message], { locale: 'fr' });
+      const [parsed] = formatter.parse(out);
+      expect(parsed).toMatchObject({
+        id: 'greeting',
+        translation: 'Bonjour',
+        comments: [],
+        references: [],
+      });
+    });
+
+    it('writes an empty object for an empty catalogue', () => {
+      const out = createJsonFormatter().stringify([], { locale: 'de' });
+      expect(JSON.parse(out)).toEqual({});
+    });
+  });
+
+  const withMeta = {
+    id: 'greeting',
+    message: 'Hello',
+    translation: 'Bonjour',
+    context: 'formal',
+    comments: ['A friendly hello'],
+    references: ['src/app.ts:10'],
+  };
+
+  describe("dialect: 'arb'", () => {
+    const formatter = createJsonFormatter({ dialect: 'arb' });
+
+    it('keeps strings flat with metadata in a sibling @key object', () => {
+      const out = JSON.parse(formatter.stringify([withMeta], { locale: 'fr' }));
+      expect(out).toEqual({
+        '@@locale': 'fr',
+        greeting: 'Bonjour',
+        '@greeting': {
+          description: 'A friendly hello',
+          'x-saykit-context': 'formal',
+          'x-saykit-references': ['src/app.ts:10'],
+        },
+      });
+    });
+
+    it('omits the @key object when a message has no metadata', () => {
+      const out = JSON.parse(
+        formatter.stringify(
+          [{ id: 'hi', message: 'Hi', translation: 'Salut', comments: [], references: [] }],
+          { locale: 'fr' },
+        ),
+      );
+      expect(out).toEqual({ '@@locale': 'fr', hi: 'Salut' });
+    });
+
+    it('parses strings and their sibling metadata, skipping @-prefixed keys', () => {
+      const messages = formatter.parse(fixture('messages.arb.json'));
+      expect(messages.map((m) => m.id).sort()).toEqual(['farewell', 'greeting']);
+      const greeting = messages.find((m) => m.id === 'greeting')!;
+      expect(greeting).toMatchObject({
+        translation: 'Bonjour',
+        context: 'formal',
+        comments: ['A friendly hello'],
+        references: ['src/app.ts:10'],
+      });
+    });
+
+    it('round-trips metadata through parse', () => {
+      const [parsed] = formatter.parse(formatter.stringify([withMeta], { locale: 'fr' }));
+      expect(parsed).toMatchObject({
+        id: 'greeting',
+        translation: 'Bonjour',
+        context: 'formal',
+        comments: ['A friendly hello'],
+        references: ['src/app.ts:10'],
+      });
+    });
+  });
+
+  describe("dialect: 'webextension'", () => {
+    const formatter = createJsonFormatter({ dialect: 'webextension' });
+
+    it('maps each key to a { message, description } object', () => {
+      const out = JSON.parse(formatter.stringify([withMeta], { locale: 'fr' }));
+      expect(out).toEqual({
+        greeting: {
+          message: 'Bonjour',
+          description: 'A friendly hello',
+          'x-saykit-context': 'formal',
+          'x-saykit-references': ['src/app.ts:10'],
+        },
+      });
+    });
+
+    it('parses the message field and its metadata', () => {
+      const messages = formatter.parse(fixture('messages.webext.json'));
+      expect(messages.map((m) => m.id).sort()).toEqual(['farewell', 'greeting']);
+      const greeting = messages.find((m) => m.id === 'greeting')!;
+      expect(greeting).toMatchObject({
+        translation: 'Bonjour',
+        context: 'formal',
+        comments: ['A friendly hello'],
+        references: ['src/app.ts:10'],
+      });
+    });
+
+    it('round-trips metadata through parse', () => {
+      const [parsed] = formatter.parse(formatter.stringify([withMeta], { locale: 'fr' }));
+      expect(parsed).toMatchObject({
+        id: 'greeting',
+        translation: 'Bonjour',
+        context: 'formal',
+        comments: ['A friendly hello'],
+        references: ['src/app.ts:10'],
+      });
+    });
+  });
+});

--- a/packages/format-json/src/formatter.ts
+++ b/packages/format-json/src/formatter.ts
@@ -1,0 +1,144 @@
+import type { Formatter, Message } from '@saykit/config';
+import { generateHash } from '@saykit/config/features/messages';
+
+type Dialect = 'arb' | 'webextension';
+
+/**
+ * Derive a catalogue key the same way the runtime and the rest of SayKit do:
+ * an explicit id when present, otherwise a stable hash of the message and its
+ * context. Keying by the raw message text instead would not match the hashed
+ * key the runtime looks up, and would collide for same-text/different-context
+ * messages.
+ */
+function messageKey(message: Message) {
+  return message.id ?? generateHash(message.message, message.context);
+}
+
+interface FormatterOptions {
+  /**
+   * The JSON dialect to write. A dialect other than the default plain
+   * `{ key: value }` map carries message metadata (comments, context, source
+   * references) using a richer — but still standard — layout.
+   *
+   * - `'arb'` — Application Resource Bundle (Flutter/Dart `intl`). Strings stay
+   *   flat and each key's metadata lives in a sibling `@key` object.
+   * - `'webextension'` — the Chrome/WebExtension `messages.json` shape, where
+   *   each key maps to a `{ message, description }` object.
+   *
+   * Both carry translator comments in their native `description` field. Context
+   * and source references have no standard slot, so they round-trip through
+   * `x-saykit-context` / `x-saykit-references` extension fields that other
+   * tooling safely ignores. Omit for a plain flat catalogue, which carries no
+   * metadata.
+   */
+  dialect?: Dialect;
+}
+
+const CONTEXT_FIELD = 'x-saykit-context';
+const REFERENCES_FIELD = 'x-saykit-references';
+
+type Attributes = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Attributes {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Build the metadata attributes shared by the ARB and WebExtension layouts. */
+function toAttributes(message: Message): Attributes {
+  const attributes: Attributes = {};
+  if (message.comments.length) attributes.description = message.comments.join('\n');
+  if (message.context) attributes[CONTEXT_FIELD] = message.context;
+  if (message.references.length) attributes[REFERENCES_FIELD] = message.references;
+  return attributes;
+}
+
+/** Reconstruct a {@link Message} from a key, its value, and optional metadata. */
+function toMessage(key: string, value: string, attributes?: Attributes): Message {
+  const description =
+    attributes && typeof attributes.description === 'string' ? attributes.description : '';
+  const context =
+    attributes && typeof attributes[CONTEXT_FIELD] === 'string'
+      ? (attributes[CONTEXT_FIELD] as string)
+      : undefined;
+  const references =
+    attributes && Array.isArray(attributes[REFERENCES_FIELD])
+      ? (attributes[REFERENCES_FIELD] as unknown[]).filter(
+          (r): r is string => typeof r === 'string',
+        )
+      : [];
+
+  return {
+    id: key,
+    message: value,
+    translation: value,
+    context,
+    comments: description ? description.split('\n') : [],
+    references,
+  };
+}
+
+function createJsonFormatter(options: FormatterOptions = {}): Formatter {
+  return {
+    extension: '.json',
+
+    parse(content) {
+      const data = JSON.parse(content) as Record<string, unknown>;
+
+      if (options.dialect === 'arb') {
+        return Object.entries(data)
+          .filter(([key, value]) => !key.startsWith('@') && typeof value === 'string')
+          .map(([key, value]) =>
+            toMessage(key, value as string, data[`@${key}`] as Attributes | undefined),
+          );
+      }
+
+      if (options.dialect === 'webextension') {
+        return Object.entries(data)
+          .filter(([, value]) => isRecord(value) && typeof value.message === 'string')
+          .map(([key, value]) => {
+            const entry = value as Attributes;
+            return toMessage(key, entry.message as string, entry);
+          });
+      }
+
+      return Object.entries(data)
+        .filter(([, value]) => typeof value === 'string')
+        .map(([key, value]) => toMessage(key, value as string));
+    },
+
+    stringify(messages, { locale }) {
+      const sorted = [...messages].sort((a, b) => messageKey(a).localeCompare(messageKey(b)));
+
+      if (options.dialect === 'arb') {
+        const catalogue: Record<string, unknown> = { '@@locale': locale };
+        for (const message of sorted) {
+          const key = messageKey(message);
+          catalogue[key] = message.translation ?? '';
+          const attributes = toAttributes(message);
+          if (Object.keys(attributes).length) catalogue[`@${key}`] = attributes;
+        }
+        return `${JSON.stringify(catalogue, null, 2)}\n`;
+      }
+
+      if (options.dialect === 'webextension') {
+        const catalogue: Record<string, unknown> = {};
+        for (const message of sorted) {
+          catalogue[messageKey(message)] = {
+            message: message.translation ?? '',
+            ...toAttributes(message),
+          };
+        }
+        return `${JSON.stringify(catalogue, null, 2)}\n`;
+      }
+
+      const catalogue: Record<string, string> = {};
+      for (const message of sorted) {
+        catalogue[messageKey(message)] = message.translation ?? '';
+      }
+      return `${JSON.stringify(catalogue, null, 2)}\n`;
+    },
+  };
+}
+
+export type { FormatterOptions, Dialect };
+export default createJsonFormatter;

--- a/packages/format-json/tsconfig.json
+++ b/packages/format-json/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../tsconfig.base.json" }

--- a/packages/format-json/tsdown.config.ts
+++ b/packages/format-json/tsdown.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/formatter.ts'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,12 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
 
+  packages/format-json:
+    devDependencies:
+      '@saykit/config':
+        specifier: workspace:^
+        version: link:../config
+
   packages/format-po:
     dependencies:
       pofile:

--- a/website/content/core-concepts/formats.mdx
+++ b/website/content/core-concepts/formats.mdx
@@ -1,6 +1,6 @@
 ---
 title: Formats
-description: PO and other translation file formats, and how to write your own
+description: PO, JSON, and other translation file formats, and how to write your own
 ---
 
 A **formatter** in SayKit is a pluggable adapter that knows how to parse and stringify one translation file format. The bucket calls it during extraction (to write) and during build (to read), but it's completely up to the formatter what file format ends up on disk.
@@ -16,7 +16,7 @@ buckets: [
 ];
 ```
 
-The default and only first-party formatter is **PO** (Gettext Portable Object). It's the format every SayKit example uses, and the one most translation tools and translators already understand.
+The default first-party formatter is **PO** (Gettext Portable Object). It's the format every SayKit example uses, and the one most translation tools and translators already understand. A **JSON** formatter ([`@saykit/format-json`](https://github.com/k0d13/saykit/tree/main/packages/format-json)) is also shipped for projects that prefer plain JSON bundles with no Gettext tooling.
 
 ## PO
 
@@ -103,9 +103,65 @@ formatter: po({ includeReferences: true, includeLineNumbers: false });
 
 Dropping line numbers is a popular choice once a project is large, references still tell translators which files use a string, but `.po` diffs no longer churn every time a line moves.
 
+## JSON
+
+`@saykit/format-json` writes one JSON catalogue per locale — the de facto format for web i18n (react-intl, FormatJS, i18next). It's a lean runtime format: each entry is keyed by its message id (falling back to a stable content hash when there's no id, the same key the runtime resolves), with the translation as the value.
+
+```ts title="saykit.config.ts"
+import json from '@saykit/format-json';
+
+buckets: [
+  {
+    // ...
+    formatter: json(),
+  },
+];
+```
+
+```json title="src/locales/fr.json"
+{
+  "greeting": "Bonjour, {name} !",
+  "inbox": "Boîte de réception"
+}
+```
+
+This plain layout is lean but drops comments, context, and source references — give your messages explicit ids to get stable, readable keys.
+
+### Dialects
+
+To keep the metadata a plain `{ key: value }` map can't hold, pass `dialect` to switch to a richer — but still standard — JSON layout.
+
+<TypeTable
+  type={{
+    dialect: {
+      description:
+        "`'arb'` for Application Resource Bundle (Flutter/Dart `intl`), where strings stay flat and each key's metadata lives in a sibling `@key` object; `'webextension'` for the Chrome `messages.json` shape, where each key maps to a `{ message, description }` object. Omit for a plain flat catalogue.",
+      type: "'arb' | 'webextension'",
+    },
+  }}
+/>
+
+```ts
+formatter: json({ dialect: 'arb' });
+```
+
+```json title="src/locales/fr.json (ARB)"
+{
+  "@@locale": "fr",
+  "greeting": "Bonjour, {name} !",
+  "@greeting": {
+    "description": "A friendly hello",
+    "x-saykit-context": "formal",
+    "x-saykit-references": ["src/app/page.tsx:14"]
+  }
+}
+```
+
+Both formats carry translator comments in their native `description` field. Context and source references have no standard slot, so SayKit round-trips them through `x-saykit-context` / `x-saykit-references` extension fields — other tooling reads the `description` and safely ignores the rest.
+
 ## Other formats
 
-PO is the only formatter shipped today. If you need JSON, YAML, XLIFF, or a custom format, you can write one yourself.
+PO and JSON are the formatters shipped today. If you need YAML, XLIFF, or a custom format, you can write one yourself.
 
 A `Formatter` is just an object:
 


### PR DESCRIPTION
Implements #35 — a new `@saykit/format-json` package that writes translations as JSON, one file per locale.

## What

- **Default**: pretty-printed flat `{ key: value }` map, keyed by message id (falling back to the source message when a message has no id).
- **`dialect` option** for richer, still-standard layouts that preserve comments, context, and source references:
  - `dialect: 'arb'` — Application Resource Bundle (Flutter/Dart `intl`); flat strings with metadata in sibling `@key` objects.
  - `dialect: 'webextension'` — Chrome `messages.json` shape (`{ message, description }` per key).
  - Both carry comments in their native `description` field; context/references round-trip through `x-saykit-context` / `x-saykit-references` extension fields other tooling ignores.
- ICU MessageFormat strings are stored verbatim as JSON string values.

## Also

- Codecov flag + component, changeset `fixed`-group entry, and a `minor` changeset.
- Docs: new JSON section in `core-concepts/formats.mdx`.

Tests, type-check, lint, and build all pass.

Blocked by #36 — this branch is stacked on top of `kodie/extract-source-locale-only`; merge that first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a JSON catalogue formatter supporting flat JSON, ARB, and WebExtension dialects.
  - Supports locale-aware output, stable message keys, ICU strings, and preservation of context, comments, and source references.
  - Added package documentation, examples, and release information.

- **Documentation**
  - Updated format documentation to include JSON configuration, usage, and dialect options.

- **Quality**
  - Added comprehensive coverage for parsing, serialisation, metadata handling, sorting, and round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->