### PR TITLE
Stat globbed files instead of using `withFileTypes` for Bun compatibility

### DIFF
--- a/.changeset/bun-glob-filetypes.md
+++ b/.changeset/bun-glob-filetypes.md
@@ -1,0 +1,5 @@
+---
+"@saykit/config": patch
+---
+
+Stat globbed files instead of using `withFileTypes`, so extraction works under Bun's `node:fs/promises` shim.

--- a/packages/config/src/features/watch.ts
+++ b/packages/config/src/features/watch.ts
@@ -17,8 +17,13 @@ import type { Bucket } from '~/shapes.js';
 export async function globBucket(bucket: Bucket) {
   const paths: string[] = [];
   for await (const path of glob(bucket.include, { exclude: bucket.exclude })) {
-    if ((await stat(path)).isFile()) {
-      paths.push(path);
+    try {
+      if ((await stat(path)).isFile()) {
+        paths.push(path);
+      }
+    } catch (error) {
+      // Ignore files removed between glob and stat, rethrow anything else.
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
     }
   }
   return paths;

--- a/packages/config/src/features/watch.ts
+++ b/packages/config/src/features/watch.ts
@@ -2,24 +2,25 @@ import type { PathLike } from 'node:fs';
 import {
   type FileChangeInfo,
   glob,
+  stat,
   type WatchOptionsWithStringEncoding,
   watch,
 } from 'node:fs/promises';
-import { join } from 'node:path';
 import type { Bucket } from '~/shapes.js';
 
 /**
  * Expand a buckets include and exclude patterns into a flat list of file paths.
+ *
+ * We stat each match instead of using `glob`'s `withFileTypes` option, which
+ * Bun's `node:fs/promises` compatibility layer does not yet support.
  */
 export async function globBucket(bucket: Bucket) {
   const paths: string[] = [];
-  for await (const file of glob(bucket.include, {
-    exclude: bucket.exclude,
-    withFileTypes: true,
-  }))
-    if (file.isFile()) {
-      paths.push(join(file.parentPath, file.name));
+  for await (const path of glob(bucket.include, { exclude: bucket.exclude })) {
+    if ((await stat(path)).isFile()) {
+      paths.push(path);
     }
+  }
   return paths;
 }
 


### PR DESCRIPTION
Fixes #44

`globBucket` in `@saykit/config` called `node:fs/promises` `glob()` with `withFileTypes: true`. Bun's `node:fs/promises` compatibility layer does not support that option (`TypeError: fs.glob does not support options.withFileTypes yet`), so `saykit extract` crashed when the CLI ran under Bun's `node` shim.

This globs for plain path strings and `stat`s each match to filter for files, which works under both real Node and Bun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file extraction from glob patterns when running under Bun, ensuring matched entries are correctly identified as files.
* **Release**
  * Published a patch release for the configuration package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->