### PR TITLE
Support TypeScript 7 and TypeScript-native runtimes in the config loader

### DIFF
--- a/.changeset/typescript-7-loader.md
+++ b/.changeset/typescript-7-loader.md
@@ -1,0 +1,5 @@
+---
+'@saykit/config': patch
+---
+
+Load config files through the host runtime (Bun, Deno, tsx) or Node's type stripping when the TypeScript compiler API is unavailable

--- a/packages/config/src/features/loader/module.test.ts
+++ b/packages/config/src/features/loader/module.test.ts
@@ -1,0 +1,112 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import nodeModule from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ts } from './module';
+
+const roots: string[] = [];
+
+function createProject(files: Record<string, string>) {
+  const root = mkdtempSync(join(tmpdir(), 'saykit-loader-'));
+  roots.push(root);
+  for (const [name, content] of Object.entries(files)) {
+    const file = join(root, name);
+    mkdirSync(join(file, '..'), { recursive: true });
+    writeFileSync(file, content);
+  }
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe('ts loader', () => {
+  it('loads a config using the TypeScript compiler API', () => {
+    // The fixture sits outside the workspace, so point it back at the real compiler.
+    const typescript = nodeModule.createRequire(import.meta.url).resolve('typescript');
+    const root = createProject({
+      'node_modules/typescript/package.json': JSON.stringify({
+        name: 'typescript',
+        version: '6.0.0',
+        main: 'index.js',
+      }),
+      'node_modules/typescript/index.js': `module.exports = require(${JSON.stringify(typescript)});`,
+      'saykit.config.ts': `
+        type Config = { locales: string[] };
+        const config: Config = { locales: ['en'] };
+        export default config;
+      `,
+    });
+
+    expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['en'] });
+  });
+
+  it('loads a config when typescript exposes no compiler API', () => {
+    // typescript@7's root export is essentially version info only.
+    const root = createProject({
+      'node_modules/typescript/package.json': JSON.stringify({
+        name: 'typescript',
+        version: '7.0.2',
+        main: 'index.js',
+      }),
+      'node_modules/typescript/index.js': 'module.exports = { version: "7.0.2" };',
+      'saykit.config.ts': `
+        enum Locale { En = 'en' }
+        const config: { locales: string[] } = { locales: [Locale.En] };
+        export default config;
+      `,
+    });
+
+    expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['en'] });
+  });
+
+  it('loads a CommonJS config when typescript exposes no compiler API', () => {
+    const root = createProject({
+      'node_modules/typescript/package.json': JSON.stringify({
+        name: 'typescript',
+        version: '7.0.2',
+        main: 'index.js',
+      }),
+      'node_modules/typescript/index.js': 'module.exports = { version: "7.0.2" };',
+      'saykit.config.cts': `
+        const config: { locales: string[] } = { locales: ['en'] };
+        module.exports = config;
+      `,
+    });
+
+    expect(ts(join(root, 'saykit.config.cts'))).toEqual({ locales: ['en'] });
+  });
+
+  it('defers to a registered .ts require hook instead of transpiling', () => {
+    const root = createProject({
+      'node_modules/.keep': '',
+      'saykit.config.ts': `
+        const config: { locales: string[] } = { locales: ['en'] };
+        module.exports = config;
+      `,
+    });
+
+    // Stands in for tsx/ts-node, which register a handler for '.ts' the same way.
+    const hooks = nodeModule.createRequire(import.meta.url).extensions;
+    const previous = hooks['.ts'];
+    hooks['.ts'] = (module, filename) => {
+      const source = nodeModule.stripTypeScriptTypes(readFileSync(filename, 'utf8'), {
+        mode: 'transform',
+      });
+      (module as unknown as { _compile: (code: string, filename: string) => void })._compile(
+        source,
+        filename,
+      );
+    };
+
+    try {
+      expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['en'] });
+      expect(existsSync(join(root, 'node_modules', '.cache'))).toBe(false);
+    } finally {
+      if (previous) hooks['.ts'] = previous;
+      else delete hooks['.ts'];
+    }
+  });
+});

--- a/packages/config/src/features/loader/module.ts
+++ b/packages/config/src/features/loader/module.ts
@@ -8,94 +8,179 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { createRequire } from 'node:module';
+import nodeModule, { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join, parse } from 'node:path';
 
 export type Loader = (path: string) => unknown;
 
-function findNearestTsConfig(fromPath: string) {
+function findUpwards<T>(fromPath: string, visit: (dir: string) => T | null): T | null {
   let dir = dirname(fromPath);
   const { root } = parse(dir);
   while (true) {
-    const candidate = join(dir, 'tsconfig.json');
-    if (existsSync(candidate)) return candidate;
+    const found = visit(dir);
+    if (found !== null) return found;
     if (dir === root) return null;
     dir = dirname(dir);
   }
 }
 
+function findNearestTsConfig(fromPath: string) {
+  return findUpwards(fromPath, (dir) => {
+    const candidate = join(dir, 'tsconfig.json');
+    return existsSync(candidate) ? candidate : null;
+  });
+}
+
 function findCacheDir(fromPath: string) {
-  let dir = dirname(fromPath);
-  const { root } = parse(dir);
-  while (true) {
-    const nm = join(dir, 'node_modules');
-    if (existsSync(nm)) return join(nm, '.cache', 'saykit', 'config');
-    if (dir === root) return join(tmpdir(), 'saykit', 'config');
-    dir = dirname(dir);
+  const nodeModules = findUpwards(fromPath, (dir) => {
+    const candidate = join(dir, 'node_modules');
+    return existsSync(candidate) ? candidate : null;
+  });
+  return nodeModules
+    ? join(nodeModules, '.cache', 'saykit', 'config')
+    : join(tmpdir(), 'saykit', 'config');
+}
+
+function digest(value: string) {
+  return createHash('sha1').update(value).digest('hex').slice(0, 16);
+}
+
+function mtimeOf(path: string | null) {
+  return path ? statSync(path).mtimeMs : 0;
+}
+
+/** Removes every build of `file` in `dir` except `keep`. */
+function pruneCache(dir: string, file: string, keep: string) {
+  for (const entry of readdirSync(dir)) {
+    if (!entry.startsWith(`${file}.`) || join(dir, entry) === keep) continue;
+    try {
+      unlinkSync(join(dir, entry));
+    } catch {}
   }
 }
 
-function transpile(path: string, tsConfigPath: string | null, require: NodeRequire) {
-  const ts = require('typescript');
-  const { config: tsConfig, error } = tsConfigPath
+/**
+ * Preferred: the classic TypeScript compiler API, which honours the project's
+ * tsconfig and emits CommonJS. TypeScript 7's root export no longer ships it,
+ * and the dependency is optional, so this gives up when it isn't there.
+ */
+function transpileWithCompilerApi(
+  source: string,
+  tsConfigPath: string | null,
+  require: NodeJS.Require,
+) {
+  let ts;
+  try {
+    ts = require('typescript');
+  } catch {
+    return null;
+  }
+  if (typeof ts?.transpileModule !== 'function' || typeof ts.sys?.readFile !== 'function') {
+    return null;
+  }
+
+  const { config, error } = tsConfigPath
     ? ts.readConfigFile(tsConfigPath, ts.sys.readFile)
     : { config: {}, error: null };
   if (error) throw error;
 
-  tsConfig.compilerOptions = {
-    ...tsConfig.compilerOptions,
+  config.compilerOptions = {
+    ...config.compilerOptions,
     allowJs: true,
     esModuleInterop: true,
+    noEmit: false,
     module: ts.ModuleKind.CommonJS,
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     target: ts.ScriptTarget.ES2022,
-    noEmit: false,
   };
 
-  return ts.transpileModule(readFileSync(path, 'utf8'), tsConfig).outputText as string;
+  return { code: ts.transpileModule(source, config).outputText as string, extension: 'cjs' };
 }
 
-function loadWithCache(path: string) {
-  const require = createRequire(path);
-  const mtimeMs = statSync(path).mtimeMs;
+/**
+ * Fallback: Node erases the types itself. It ignores tsconfig and leaves the
+ * module syntax alone, so the extension has to follow the source.
+ */
+function transpileWithNode(source: string) {
+  if (typeof nodeModule.stripTypeScriptTypes !== 'function') {
+    throw new Error(
+      'Loading TypeScript config files requires the TypeScript compiler API (typescript <= 6), Node 22.13+, or a runtime that loads TypeScript itself (Bun, Deno, tsx)',
+    );
+  }
+
+  const code = nodeModule.stripTypeScriptTypes(source, { mode: 'transform' });
+  return { code, extension: /^\s*(?:import|export)[\s({]/m.test(code) ? 'mjs' : 'cjs' };
+}
+
+/**
+ * Writes a plain JavaScript copy of `path` next to the project's dependencies
+ * and returns it. Copies are named `<file>.<inputs>.<extension>`, so a build
+ * can be reused until its inputs change, and earlier builds of the same file
+ * can be pruned once it does.
+ */
+function compileToCache(path: string, require: NodeJS.Require) {
   const tsConfigPath = findNearestTsConfig(path);
-  const tsConfigMtimeMs = tsConfigPath ? statSync(tsConfigPath).mtimeMs : 0;
-  const hash = createHash('sha1')
-    .update(`${path}\0${tsConfigPath ?? ''}\0${tsConfigMtimeMs}`)
-    .digest('hex')
-    .slice(0, 16);
-  const cacheDir = findCacheDir(path);
-  const cachePath = join(cacheDir, `${hash}.${mtimeMs}.cjs`);
+  const dir = findCacheDir(path);
+  const file = digest(path);
+  const inputs = digest(`${mtimeOf(path)}\0${tsConfigPath}\0${mtimeOf(tsConfigPath)}`);
 
+  const cached = ['cjs', 'mjs']
+    .map((ext) => join(dir, `${file}.${inputs}.${ext}`))
+    .find(existsSync);
+  if (cached) return cached;
+
+  const source = readFileSync(path, 'utf8');
+  const { code, extension } =
+    transpileWithCompilerApi(source, tsConfigPath, require) ?? transpileWithNode(source);
+  const target = join(dir, `${file}.${inputs}.${extension}`);
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(target, code);
+  pruneCache(dir, file, target);
+  return target;
+}
+
+/**
+ * Bun, Deno and hooks like tsx or ts-node load TypeScript better than we can,
+ * resolving tsconfig `paths` and the project's own module resolution with it.
+ */
+function runtimeLoadsTypeScript(require: NodeJS.Require) {
+  return Boolean(
+    process.versions.bun ||
+    (globalThis as { Deno?: unknown }).Deno ||
+    require.extensions?.['.ts'] ||
+    Reflect.get(process, Symbol.for('ts-node.register.instance')),
+  );
+}
+
+/** Requires `path` without leaving it in (or reading it from) the require cache. */
+function requireFresh(require: NodeJS.Require, path: string) {
+  const resolved = require.resolve(path);
+  delete require.cache[resolved];
+  const module = require(path);
+  delete require.cache[resolved];
+  return module?.default ?? module;
+}
+
+/**
+ * Loads a config file, compiling it first unless the runtime reads TypeScript
+ * on its own.
+ */
+function loadModule(path: string) {
+  const require = createRequire(path);
   try {
-    if (!existsSync(cachePath)) {
-      mkdirSync(cacheDir, { recursive: true });
-      writeFileSync(cachePath, transpile(path, tsConfigPath, require));
-
-      if (existsSync(cacheDir)) {
-        for (const entry of readdirSync(cacheDir)) {
-          if (entry.startsWith(`${hash}.`) && entry !== `${hash}.${mtimeMs}.cjs`) {
-            try {
-              unlinkSync(join(cacheDir, entry));
-            } catch {}
-          }
-        }
-      }
-    }
-
-    const resolved = require.resolve(cachePath);
-    delete require.cache[resolved];
-    const module = require(cachePath);
-    delete require.cache[resolved];
-    return module?.default ?? module;
+    return requireFresh(
+      require,
+      runtimeLoadsTypeScript(require) ? path : compileToCache(path, require),
+    );
   } catch (error) {
     throw new Error('Failed to import module', { cause: error });
   }
 }
 
-export const js: Loader = (path) => loadWithCache(path);
-export const ts: Loader = (path) => loadWithCache(path);
+export const js: Loader = loadModule;
+export const ts: Loader = loadModule;
 
 export const configLoaders = Object.freeze({
   '.js': js,

--- a/packages/config/src/features/loader/module.ts
+++ b/packages/config/src/features/loader/module.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import nodeModule, { createRequire } from 'node:module';
-import { tmpdir } from 'node:os';
+import { tmpdir, userInfo } from 'node:os';
 import { dirname, join, parse } from 'node:path';
 
 export type Loader = (path: string) => unknown;
@@ -32,18 +32,25 @@ function findNearestTsConfig(fromPath: string) {
   });
 }
 
+function digest(value: string) {
+  return createHash('sha1').update(value).digest('hex').slice(0, 16);
+}
+
+/**
+ * Builds are executable, so they belong beside the project's dependencies. The
+ * fallback lands in a shared temp directory instead, where a fixed path would
+ * let any other user on the machine plant code we later require — hence a
+ * per-user directory, created private in `compileToCache`.
+ */
 function findCacheDir(fromPath: string) {
   const nodeModules = findUpwards(fromPath, (dir) => {
     const candidate = join(dir, 'node_modules');
     return existsSync(candidate) ? candidate : null;
   });
-  return nodeModules
-    ? join(nodeModules, '.cache', 'saykit', 'config')
-    : join(tmpdir(), 'saykit', 'config');
-}
+  if (nodeModules) return join(nodeModules, '.cache', 'saykit', 'config');
 
-function digest(value: string) {
-  return createHash('sha1').update(value).digest('hex').slice(0, 16);
+  const { uid, username, homedir } = userInfo();
+  return join(tmpdir(), `saykit-config-${digest(`${uid}\0${username}\0${homedir}`)}`);
 }
 
 function mtimeOf(path: string | null) {
@@ -135,8 +142,8 @@ function compileToCache(path: string, require: NodeJS.Require) {
     transpileWithCompilerApi(source, tsConfigPath, require) ?? transpileWithNode(source);
   const target = join(dir, `${file}.${inputs}.${extension}`);
 
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(target, code);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(target, code, { mode: 0o600 });
   pruneCache(dir, file, target);
   return target;
 }


### PR DESCRIPTION
`@saykit/config` reached straight for the classic TypeScript compiler API — `ts.sys.readFile`, `ts.readConfigFile`, `ts.transpileModule` — the moment it loaded a config file. typescript@7's root export no longer ships that API, so the first property access threw before the config was ever read:

```
TypeError: Cannot read properties of undefined (reading 'readFile')
```

The same crash hit anyone with no TypeScript installed at all, since it's an optional peer dependency.

## What changed

The loader now picks a strategy instead of assuming one:

1. **The runtime, if it reads TypeScript itself.** Bun, Deno and hooks like tsx or ts-node get handed the source file directly — no transpile, no cache. They resolve tsconfig `paths` and the project's own module resolution while doing it, which is strictly better than anything we can do by hand.
2. **The compiler API**, when it's actually there. Unchanged behaviour for typescript <= 6: honours the project's tsconfig, emits CommonJS.
3. **Node's type stripping** (`module.stripTypeScriptTypes`, Node 22.13+) as a fallback. It runs in `transform` mode so enums and namespaces still work, but it ignores tsconfig and preserves the source's module syntax — so cached copies are now written as `.mjs` or `.cjs` depending on what the source used.

If none of the three is available the error names all three requirements rather than throwing a `TypeError` on `undefined`.

`process.features.typescript` is deliberately *not* used as a trigger. It's `'strip'` by default on Node 22.18+/24, so keying off it would preempt the compiler-API path for every existing user — losing tsconfig `paths` and erroring on enums. Node's stripping stays last for that reason.

## Notes

- This does not move the repo to typescript 7; the dev dependency stays on 6 and the optional peer stays `*`. It's feature detection, so local and CI builds take exactly the same path they did before.
- `runtimeLoadsTypeScript` gates *all* config files, not just `.ts`. Under Bun or a tsx hook a `.js` config is now required directly rather than transpiled and cached. Intentional — those runtimes handle ESM and resolution themselves — but it's the one change that touches JavaScript configs too.
- The rest of the diff is a restructure of `module.ts` around the new branch: the cache read/write/prune logic is one function, the two transpilers are siblings behind a `??`, and cached copies are named `<file>.<inputs>.<extension>` so a build is reused until its inputs change and older builds of the same file can be pruned.
- No direct coverage of the Bun path — there's no Bun in this repo. It's a `process.versions.bun` check, but worth a manual run before release.

## Tests

`module.test.ts` covers all four branches, faking each environment with a fixture project: the compiler API (pointed at the real compiler), typescript@7 exposing only `{ version }` for both an ESM config with an enum and a CommonJS one, and a registered `.ts` require hook standing in for tsx — that last one also asserts nothing was written to the cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved TypeScript configuration loading across Bun, Deno, tsx, and Node.js environments.
  - Added fallback support for loading TypeScript configurations when the TypeScript compiler API is unavailable.
  - Supports both ESM and CommonJS configuration formats.

- **Bug Fixes**
  - Prevents stale configuration modules from being reused after changes.
  - Improved handling of existing TypeScript runtime loaders and configuration caching.

- **Tests**
  - Added coverage for compiler-based loading, runtime fallbacks, module formats, and custom TypeScript loaders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->