### PR TITLE
Release every package under one version, tag, and GitHub release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,8 +3,10 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [
-    ["saykit", "@saykit/carbon", "@saykit/react"],
     [
+      "saykit",
+      "@saykit/carbon",
+      "@saykit/react",
       "@saykit/config",
       "@saykit/format-json",
       "@saykit/format-po",

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -136,7 +136,7 @@ jobs:
     needs: [check, lint, test]
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.publish.outputs.published || 'false' }}
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
@@ -161,40 +161,53 @@ jobs:
           title: 'Pending Releases'
           commit: 'Update changelog and release'
 
+      # `changeset publish` skips anything already on the registry, so this is
+      # safe to re-run: a rerun after a partial failure publishes the remainder.
       - name: Publish packages
-        id: publish
         if: ${{ steps.changesets.outputs.hasChangesets == 'false' }}
-        run: |
-          set -o pipefail
-          pnpm run release:publish | tee publish.log
-          if grep -q 'packages published successfully' publish.log; then
-            echo 'published=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'published=false' >> "$GITHUB_OUTPUT"
-          fi
+        run: pnpm run release:publish
 
       - name: Build release notes
         id: notes
-        if: ${{ steps.publish.outputs.published == 'true' }}
+        if: ${{ steps.changesets.outputs.hasChangesets == 'false' }}
         run: node scripts/release-notes.mjs
 
+      # Driven by the version on disk rather than by whether this run happened
+      # to publish, so a rerun can finish a release whose tag or GitHub release
+      # was left behind by an earlier failure. Both are no-ops once they exist.
       - name: Tag and create release
-        if: ${{ steps.publish.outputs.published == 'true' }}
+        if: ${{ steps.changesets.outputs.hasChangesets == 'false' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.notes.outputs.version }}
         run: |
-          git tag "v$VERSION"
-          git push origin "v$VERSION"
-          gh release create "v$VERSION" \
-            --title "v$VERSION" \
-            --notes-file RELEASE_NOTES.md
+          if [ -z "$VERSION" ]; then
+            echo 'No shared version to release.'
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists."
+          else
+            git tag "v$VERSION"
+            git push origin "v$VERSION"
+          fi
+
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists."
+          else
+            gh release create "v$VERSION" \
+              --title "v$VERSION" \
+              --notes-file RELEASE_NOTES.md
+          fi
 
   snapshot:
     name: Releasing Snapshot
     needs: [process]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.process.outputs.published == 'false' }}
+    # Betas exist to preview changes that are waiting on a release, so this
+    # keys off pending changesets rather than off whether a publish happened.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.process.outputs.hasChangesets == 'true' }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -136,7 +136,7 @@ jobs:
     needs: [check, lint, test]
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.changesets.outputs.published }}
+      published: ${{ steps.publish.outputs.published || 'false' }}
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
@@ -150,17 +150,45 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/node
 
+      # Only maintains the version PR. Publishing is done below so that a
+      # release produces one tag and one GitHub release for the whole
+      # workspace, rather than one of each per package.
       - name: Process changesets
         id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm run release:version
-          publish: pnpm run release:publish
           title: 'Pending Releases'
           commit: 'Update changelog and release'
 
-      - run: |
-          echo "published=${{ steps.changesets.outputs.published }}" >> $GITHUB_OUTPUT
+      - name: Publish packages
+        id: publish
+        if: ${{ steps.changesets.outputs.hasChangesets == 'false' }}
+        run: |
+          set -o pipefail
+          pnpm run release:publish | tee publish.log
+          if grep -q 'packages published successfully' publish.log; then
+            echo 'published=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'published=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release notes
+        id: notes
+        if: ${{ steps.publish.outputs.published == 'true' }}
+        run: node scripts/release-notes.mjs
+
+      - name: Tag and create release
+        if: ${{ steps.publish.outputs.published == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.notes.outputs.version }}
+        run: |
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file RELEASE_NOTES.md
 
   snapshot:
     name: Releasing Snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 .turbo/
 .coverage/
 dist/
+publish.log
+RELEASE_NOTES.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ node_modules/
 .turbo/
 .coverage/
 dist/
-publish.log
 RELEASE_NOTES.md

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "turbo watch build --filter=\"./packages/*\"",
     "release:version": "changeset version",
     "release:snapshot:version": "changeset version --snapshot beta",
-    "release:publish": "pnpm build && changeset publish",
+    "release:publish": "pnpm build && changeset publish --no-git-tag",
     "release:snapshot:publish": "pnpm build && changeset publish --tag beta --no-git-tag"
   },
   "devDependencies": {

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,94 @@
+// Builds the body for the single GitHub release that covers a version bump.
+//
+// Every publishable package shares one version (see the `fixed` group in
+// .changeset/config.json), so the release notes are just each package's
+// changelog section for that version, concatenated.
+//
+// Writes RELEASE_NOTES.md and exports `version` to $GITHUB_OUTPUT when running
+// in Actions; prints the notes to stdout otherwise.
+
+import { appendFile, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packagesDir = fileURLToPath(new URL('../packages/', import.meta.url));
+
+const readJson = async (path) => JSON.parse(await readFile(path, 'utf8'));
+
+const readChangelogSection = async (dir, version) => {
+  let changelog;
+
+  try {
+    changelog = await readFile(join(dir, 'CHANGELOG.md'), 'utf8');
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    return null;
+  }
+
+  // Sections are `## <version>` and run until the next `## ` heading.
+  const pattern = new RegExp(
+    `^## ${version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$([\\s\\S]*?)(?=^## |$(?![\\s\\S]))`,
+    'm',
+  );
+
+  const section = changelog.match(pattern)?.[1]?.trim();
+
+  return section || null;
+};
+
+const collect = async () => {
+  const entries = await readdir(packagesDir, { withFileTypes: true });
+  const packages = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const dir = join(packagesDir, entry.name);
+    let manifest;
+
+    try {
+      manifest = await readJson(join(dir, 'package.json'));
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+      continue;
+    }
+
+    if (manifest.private || !manifest.version) continue;
+
+    packages.push({ dir, name: manifest.name, version: manifest.version });
+  }
+
+  return packages.sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const packages = await collect();
+
+if (packages.length === 0) {
+  throw new Error('No publishable packages found under packages/');
+}
+
+const versions = [...new Set(packages.map((pkg) => pkg.version))];
+
+if (versions.length > 1) {
+  throw new Error(
+    `Expected every publishable package to share one version, found: ${versions.join(', ')}`,
+  );
+}
+
+const [version] = versions;
+const sections = [];
+
+for (const pkg of packages) {
+  const section = await readChangelogSection(pkg.dir, version);
+  if (section) sections.push(`## ${pkg.name}\n\n${section}`);
+}
+
+const notes =
+  sections.length > 0 ? sections.join('\n\n') : `No changelog entries recorded for ${version}.`;
+
+if (process.env.GITHUB_OUTPUT) {
+  await writeFile('RELEASE_NOTES.md', `${notes}\n`);
+  await appendFile(process.env.GITHUB_OUTPUT, `version=${version}\n`);
+} else {
+  process.stdout.write(`${notes}\n`);
+}

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -69,10 +69,15 @@ if (packages.length === 0) {
 
 const versions = [...new Set(packages.map((pkg) => pkg.version))];
 
+// A single tag only makes sense once the whole workspace shares a version.
+// Packages predating the merged `fixed` group are still on their old versions
+// until the next release bumps everything in lockstep, so emit nothing and let
+// the caller skip tagging rather than failing the pipeline.
 if (versions.length > 1) {
-  throw new Error(
-    `Expected every publishable package to share one version, found: ${versions.join(', ')}`,
+  process.stderr.write(
+    `Skipping release notes: packages are on mixed versions (${versions.join(', ')}).\n`,
   );
+  process.exit(0);
 }
 
 const [version] = versions;


### PR DESCRIPTION
Closes #47.

Two changes, since the issue is really two asks.

### One version across the workspace

`.changeset/config.json` had two `fixed` groups, which is why `saykit` sits at `0.2.1` while `@saykit/config` is at `0.4.0`. They're now one group, so everything bumps in lockstep.

Note this pulls `saykit`, `@saykit/carbon`, and `@saykit/react` from `0.2.1` up to whatever the next bump off `0.4.0` is. The trade is that a patch to one package bumps all of them, so some packages will ship releases with no changelog entries of their own.

### One tag and one GitHub release

`fixed` only unifies version numbers — `changeset publish` still writes a git tag per package, and `changesets/action` turns each tag into its own GitHub release. There's no built-in single-tag mode, so publishing moves out of the action:

- `changesets/action` now only maintains the "Pending Releases" PR (`publish:` input dropped)
- `release:publish` passes `--no-git-tag`
- a new step publishes, then tags `v<version>` and creates one GitHub release

Because the action no longer publishes, its `published` output is no longer meaningful, so the job output is derived from the publish step instead — it greps changesets' `packages published successfully` line. The `snapshot` job's condition is unchanged and still gets `'false'` when nothing was published (including when the publish step is skipped because a version PR is pending).

`scripts/release-notes.mjs` builds the release body by pulling each package's changelog section for the released version and concatenating them. It hard-fails if the publishable packages aren't all on the same version, which is the assumption the single tag rests on.

### Verification

The notes script is tested against a fixture workspace — correct extraction for both a mid-file section and a trailing one, private packages skipped, `version` exported to `$GITHUB_OUTPUT`. The workflow path can't be exercised without a real release, so the first release after merge is worth watching.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated generation of GitHub release notes from package changelogs.
  - Releases now include the shared package version and relevant package updates.

- **Bug Fixes**
  - Improved release status handling so publishing success is reported reliably.

- **Chores**
  - Streamlined the publishing workflow to separate package publishing from version updates.
  - Prevented duplicate automatic tags so releases can be tagged consistently.
  - Excluded generated release files and publishing logs from source control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->