### PR TITLE
Load config files directly instead of transpiling them to a cache

### DIFF
--- a/.changeset/config-relative-imports.md
+++ b/.changeset/config-relative-imports.md
@@ -1,0 +1,5 @@
+---
+'@saykit/config': minor
+---
+
+Load config files directly rather than transpiling them to a cache, fixing relative imports and `import.meta.dirname` — now requires Node 22.18+ or a runtime that reads TypeScript itself

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -87,12 +87,7 @@
   "devDependencies": {
     "@types/picomatch": "^4.0.3"
   },
-  "peerDependencies": {
-    "typescript": "*"
-  },
-  "peerDependenciesMeta": {
-    "typescript": {
-      "optional": true
-    }
+  "engines": {
+    "node": ">=22.18"
   }
 }

--- a/packages/config/src/features/loader/module.test.ts
+++ b/packages/config/src/features/loader/module.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import nodeModule from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -23,16 +23,8 @@ afterEach(() => {
 });
 
 describe('ts loader', () => {
-  it('loads a config using the TypeScript compiler API', () => {
-    // The fixture sits outside the workspace, so point it back at the real compiler.
-    const typescript = nodeModule.createRequire(import.meta.url).resolve('typescript');
+  it('loads a TypeScript config', () => {
     const root = createProject({
-      'node_modules/typescript/package.json': JSON.stringify({
-        name: 'typescript',
-        version: '6.0.0',
-        main: 'index.js',
-      }),
-      'node_modules/typescript/index.js': `module.exports = require(${JSON.stringify(typescript)});`,
       'saykit.config.ts': `
         type Config = { locales: string[] };
         const config: Config = { locales: ['en'] };
@@ -43,33 +35,8 @@ describe('ts loader', () => {
     expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['en'] });
   });
 
-  it('loads a config when typescript exposes no compiler API', () => {
-    // typescript@7's root export is essentially version info only.
+  it('loads a CommonJS config', () => {
     const root = createProject({
-      'node_modules/typescript/package.json': JSON.stringify({
-        name: 'typescript',
-        version: '7.0.2',
-        main: 'index.js',
-      }),
-      'node_modules/typescript/index.js': 'module.exports = { version: "7.0.2" };',
-      'saykit.config.ts': `
-        enum Locale { En = 'en' }
-        const config: { locales: string[] } = { locales: [Locale.En] };
-        export default config;
-      `,
-    });
-
-    expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['en'] });
-  });
-
-  it('loads a CommonJS config when typescript exposes no compiler API', () => {
-    const root = createProject({
-      'node_modules/typescript/package.json': JSON.stringify({
-        name: 'typescript',
-        version: '7.0.2',
-        main: 'index.js',
-      }),
-      'node_modules/typescript/index.js': 'module.exports = { version: "7.0.2" };',
       'saykit.config.cts': `
         const config: { locales: string[] } = { locales: ['en'] };
         module.exports = config;
@@ -79,9 +46,8 @@ describe('ts loader', () => {
     expect(ts(join(root, 'saykit.config.cts'))).toEqual({ locales: ['en'] });
   });
 
-  it('defers to a registered .ts require hook instead of transpiling', () => {
+  it('defers to a registered .ts require hook', () => {
     const root = createProject({
-      'node_modules/.keep': '',
       'saykit.config.ts': `
         const config: { locales: string[] } = { locales: ['en'] };
         module.exports = config;
@@ -103,10 +69,83 @@ describe('ts loader', () => {
 
     try {
       expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['en'] });
-      expect(existsSync(join(root, 'node_modules', '.cache'))).toBe(false);
     } finally {
       if (previous) hooks['.ts'] = previous;
       else delete hooks['.ts'];
     }
+  });
+
+  it('resolves a relative import against the config’s own directory', () => {
+    const root = createProject({
+      'formatter.ts': `export const locales: string[] = ['en', 'fr'];`,
+      'saykit.config.ts': `
+        import { locales } from './formatter.ts';
+        export default { locales };
+      `,
+    });
+
+    expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['en', 'fr'] });
+  });
+
+  it('resolves a nested relative import', () => {
+    const root = createProject({
+      'saykit/formatter.ts': `export { locales } from './locales.ts';`,
+      'saykit/locales.ts': `export const locales: string[] = ['de'];`,
+      'saykit.config.ts': `
+        import { locales } from './saykit/formatter.ts';
+        export default { locales };
+      `,
+    });
+
+    expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['de'] });
+  });
+
+  it('reads a file next to the config', () => {
+    const root = createProject({
+      'locales.json': JSON.stringify(['ja']),
+      'saykit.config.ts': `
+        import { readFileSync } from 'node:fs';
+        import { join } from 'node:path';
+
+        const here: string = import.meta.dirname;
+        export default { locales: JSON.parse(readFileSync(join(here, 'locales.json'), 'utf8')) };
+      `,
+    });
+
+    expect(ts(join(root, 'saykit.config.ts'))).toEqual({ locales: ['ja'] });
+  });
+
+  it('leaves nothing behind on disk', () => {
+    const root = createProject({
+      'saykit.config.ts': `export default { locales: ['en'] };`,
+    });
+
+    ts(join(root, 'saykit.config.ts'));
+
+    expect(readdirSync(root)).toEqual(['saykit.config.ts']);
+  });
+
+  it('surfaces an error thrown by the config itself', () => {
+    const root = createProject({ 'saykit.config.ts': `throw new Error('boom');` });
+
+    try {
+      ts(join(root, 'saykit.config.ts'));
+      expect.unreachable();
+    } catch (error) {
+      expect((error as Error).message).toBe('Failed to import module');
+      expect((error as Error).cause).toMatchObject({ message: 'boom' });
+    }
+  });
+
+  it('explains itself when the runtime cannot read the syntax', () => {
+    const root = createProject({
+      // Enums are not erasable, so no type-stripping runtime accepts them.
+      'saykit.config.ts': `
+        enum Locale { En = 'en' }
+        export default { locales: [Locale.En] };
+      `,
+    });
+
+    expect(() => ts(join(root, 'saykit.config.ts'))).toThrow('Node 22.18+');
   });
 });

--- a/packages/config/src/features/loader/module.test.ts
+++ b/packages/config/src/features/loader/module.test.ts
@@ -137,15 +137,43 @@ describe('ts loader', () => {
     }
   });
 
-  it('explains itself when the runtime cannot read the syntax', () => {
+  it('explains non-erasable syntax', () => {
     const root = createProject({
-      // Enums are not erasable, so no type-stripping runtime accepts them.
       'saykit.config.ts': `
         enum Locale { En = 'en' }
         export default { locales: [Locale.En] };
       `,
     });
 
-    expect(() => ts(join(root, 'saykit.config.ts'))).toThrow('Node 22.18+');
+    expect(() => ts(join(root, 'saykit.config.ts'))).toThrow('not erasable');
+  });
+
+  it('explains top-level await', () => {
+    const root = createProject({
+      'saykit.config.ts': `
+        await Promise.resolve();
+        export default { locales: ['en'] };
+      `,
+    });
+
+    expect(() => ts(join(root, 'saykit.config.ts'))).toThrow('top-level await');
+  });
+
+  it('does not blame TypeScript for a syntax error in a JavaScript config', () => {
+    const root = createProject({ 'saykit.config.js': `export default { locales: [ };` });
+
+    try {
+      ts(join(root, 'saykit.config.js'));
+      expect.unreachable();
+    } catch (error) {
+      expect((error as Error).message).toBe('Failed to import module');
+      expect((error as Error).cause).toBeInstanceOf(SyntaxError);
+    }
+  });
+
+  it('does not blame the runtime for a syntax error in a TypeScript config', () => {
+    const root = createProject({ 'saykit.config.ts': `export default { locales: [ };` });
+
+    expect(() => ts(join(root, 'saykit.config.ts'))).toThrow(/^Failed to import module$/);
   });
 });

--- a/packages/config/src/features/loader/module.ts
+++ b/packages/config/src/features/loader/module.ts
@@ -1,165 +1,6 @@
-import { createHash } from 'node:crypto';
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
-import nodeModule, { createRequire } from 'node:module';
-import { tmpdir, userInfo } from 'node:os';
-import { dirname, join, parse } from 'node:path';
+import { createRequire } from 'node:module';
 
 export type Loader = (path: string) => unknown;
-
-function findUpwards<T>(fromPath: string, visit: (dir: string) => T | null): T | null {
-  let dir = dirname(fromPath);
-  const { root } = parse(dir);
-  while (true) {
-    const found = visit(dir);
-    if (found !== null) return found;
-    if (dir === root) return null;
-    dir = dirname(dir);
-  }
-}
-
-function findNearestTsConfig(fromPath: string) {
-  return findUpwards(fromPath, (dir) => {
-    const candidate = join(dir, 'tsconfig.json');
-    return existsSync(candidate) ? candidate : null;
-  });
-}
-
-function digest(value: string) {
-  return createHash('sha1').update(value).digest('hex').slice(0, 16);
-}
-
-/**
- * Builds are executable, so they belong beside the project's dependencies. The
- * fallback lands in a shared temp directory instead, where a fixed path would
- * let any other user on the machine plant code we later require — hence a
- * per-user directory, created private in `compileToCache`.
- */
-function findCacheDir(fromPath: string) {
-  const nodeModules = findUpwards(fromPath, (dir) => {
-    const candidate = join(dir, 'node_modules');
-    return existsSync(candidate) ? candidate : null;
-  });
-  if (nodeModules) return join(nodeModules, '.cache', 'saykit', 'config');
-
-  const { uid, username, homedir } = userInfo();
-  return join(tmpdir(), `saykit-config-${digest(`${uid}\0${username}\0${homedir}`)}`);
-}
-
-function mtimeOf(path: string | null) {
-  return path ? statSync(path).mtimeMs : 0;
-}
-
-/** Removes every build of `file` in `dir` except `keep`. */
-function pruneCache(dir: string, file: string, keep: string) {
-  for (const entry of readdirSync(dir)) {
-    if (!entry.startsWith(`${file}.`) || join(dir, entry) === keep) continue;
-    try {
-      unlinkSync(join(dir, entry));
-    } catch {}
-  }
-}
-
-/**
- * Preferred: the classic TypeScript compiler API, which honours the project's
- * tsconfig and emits CommonJS. TypeScript 7's root export no longer ships it,
- * and the dependency is optional, so this gives up when it isn't there.
- */
-function transpileWithCompilerApi(
-  source: string,
-  tsConfigPath: string | null,
-  require: NodeJS.Require,
-) {
-  let ts;
-  try {
-    ts = require('typescript');
-  } catch {
-    return null;
-  }
-  if (typeof ts?.transpileModule !== 'function' || typeof ts.sys?.readFile !== 'function') {
-    return null;
-  }
-
-  const { config, error } = tsConfigPath
-    ? ts.readConfigFile(tsConfigPath, ts.sys.readFile)
-    : { config: {}, error: null };
-  if (error) throw error;
-
-  config.compilerOptions = {
-    ...config.compilerOptions,
-    allowJs: true,
-    esModuleInterop: true,
-    noEmit: false,
-    module: ts.ModuleKind.CommonJS,
-    moduleResolution: ts.ModuleResolutionKind.NodeJs,
-    target: ts.ScriptTarget.ES2022,
-  };
-
-  return { code: ts.transpileModule(source, config).outputText as string, extension: 'cjs' };
-}
-
-/**
- * Fallback: Node erases the types itself. It ignores tsconfig and leaves the
- * module syntax alone, so the extension has to follow the source.
- */
-function transpileWithNode(source: string) {
-  if (typeof nodeModule.stripTypeScriptTypes !== 'function') {
-    throw new Error(
-      'Loading TypeScript config files requires the TypeScript compiler API (typescript <= 6), Node 22.13+, or a runtime that loads TypeScript itself (Bun, Deno, tsx)',
-    );
-  }
-
-  const code = nodeModule.stripTypeScriptTypes(source, { mode: 'transform' });
-  return { code, extension: /^\s*(?:import|export)[\s({]/m.test(code) ? 'mjs' : 'cjs' };
-}
-
-/**
- * Writes a plain JavaScript copy of `path` next to the project's dependencies
- * and returns it. Copies are named `<file>.<inputs>.<extension>`, so a build
- * can be reused until its inputs change, and earlier builds of the same file
- * can be pruned once it does.
- */
-function compileToCache(path: string, require: NodeJS.Require) {
-  const tsConfigPath = findNearestTsConfig(path);
-  const dir = findCacheDir(path);
-  const file = digest(path);
-  const inputs = digest(`${mtimeOf(path)}\0${tsConfigPath}\0${mtimeOf(tsConfigPath)}`);
-
-  const cached = ['cjs', 'mjs']
-    .map((ext) => join(dir, `${file}.${inputs}.${ext}`))
-    .find(existsSync);
-  if (cached) return cached;
-
-  const source = readFileSync(path, 'utf8');
-  const { code, extension } =
-    transpileWithCompilerApi(source, tsConfigPath, require) ?? transpileWithNode(source);
-  const target = join(dir, `${file}.${inputs}.${extension}`);
-
-  mkdirSync(dir, { recursive: true, mode: 0o700 });
-  writeFileSync(target, code, { mode: 0o600 });
-  pruneCache(dir, file, target);
-  return target;
-}
-
-/**
- * Bun, Deno and hooks like tsx or ts-node load TypeScript better than we can,
- * resolving tsconfig `paths` and the project's own module resolution with it.
- */
-function runtimeLoadsTypeScript(require: NodeJS.Require) {
-  return Boolean(
-    process.versions.bun ||
-    (globalThis as { Deno?: unknown }).Deno ||
-    require.extensions?.['.ts'] ||
-    Reflect.get(process, Symbol.for('ts-node.register.instance')),
-  );
-}
 
 /** Requires `path` without leaving it in (or reading it from) the require cache. */
 function requireFresh(require: NodeJS.Require, path: string) {
@@ -171,18 +12,43 @@ function requireFresh(require: NodeJS.Require, path: string) {
 }
 
 /**
- * Loads a config file, compiling it first unless the runtime reads TypeScript
- * on its own.
+ * Errors that mean the runtime cannot read the file at all, as opposed to the
+ * config itself failing. Node has read TypeScript since 22.18; Bun, Deno and
+ * hooks like tsx or ts-node always have.
+ */
+const UNREADABLE = new Set([
+  'ERR_UNKNOWN_FILE_EXTENSION',
+  'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX',
+  'ERR_INVALID_TYPESCRIPT_SYNTAX',
+  'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING',
+]);
+
+/**
+ * A `SyntaxError` counts too: a runtime with no TypeScript support parses the
+ * annotations as JavaScript and chokes on the first one.
+ */
+function runtimeCannotRead(error: unknown) {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  return (code !== undefined && UNREADABLE.has(code)) || error instanceof SyntaxError;
+}
+
+const HINT =
+  'Reading this config needs Node 22.18+, or a runtime that loads TypeScript itself (Bun, Deno, tsx).';
+
+/**
+ * Loads a config file as it sits on disk, leaving the runtime to deal with the
+ * extension. Nothing is copied or rewritten, so `__dirname`,
+ * `import.meta.dirname`, relative specifiers and `require.resolve` all resolve
+ * against the config's own directory.
  */
 function loadModule(path: string) {
-  const require = createRequire(path);
   try {
-    return requireFresh(
-      require,
-      runtimeLoadsTypeScript(require) ? path : compileToCache(path, require),
-    );
+    return requireFresh(createRequire(path), path);
   } catch (error) {
-    throw new Error('Failed to import module', { cause: error });
+    const message = runtimeCannotRead(error)
+      ? `Failed to import module. ${HINT}`
+      : 'Failed to import module';
+    throw new Error(message, { cause: error });
   }
 }
 

--- a/packages/config/src/features/loader/module.ts
+++ b/packages/config/src/features/loader/module.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { extname } from 'node:path';
 
 export type Loader = (path: string) => unknown;
 
@@ -11,29 +12,35 @@ function requireFresh(require: NodeJS.Require, path: string) {
   return module?.default ?? module;
 }
 
-/**
- * Errors that mean the runtime cannot read the file at all, as opposed to the
- * config itself failing. Node has read TypeScript since 22.18; Bun, Deno and
- * hooks like tsx or ts-node always have.
- */
-const UNREADABLE = new Set([
-  'ERR_UNKNOWN_FILE_EXTENSION',
-  'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX',
-  'ERR_INVALID_TYPESCRIPT_SYNTAX',
-  'ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING',
-]);
+const TYPESCRIPT = new Set(['.ts', '.mts', '.cts']);
 
 /**
- * A `SyntaxError` counts too: a runtime with no TypeScript support parses the
- * annotations as JavaScript and chokes on the first one.
+ * Adds what the runtime cannot: why a config it could not read is one it will
+ * never read. Everything else is the config's own problem, and its error
+ * already describes that better than we could.
  */
-function runtimeCannotRead(error: unknown) {
+function diagnose(error: unknown, path: string) {
   const code = (error as NodeJS.ErrnoException | null)?.code;
-  return (code !== undefined && UNREADABLE.has(code)) || error instanceof SyntaxError;
-}
 
-const HINT =
-  'Reading this config needs Node 22.18+, or a runtime that loads TypeScript itself (Bun, Deno, tsx).';
+  if (code === 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX') {
+    return 'Enums, namespaces and parameter properties are not erasable, so no runtime will read them.';
+  }
+  if (code === 'ERR_REQUIRE_ASYNC_MODULE') {
+    return 'The config is loaded synchronously, so it cannot use top-level await.';
+  }
+
+  // A runtime with no TypeScript support parses the annotations as JavaScript
+  // and chokes on the first one, leaving a plain `SyntaxError` to say so. One
+  // that does support it reports its own syntax errors with a code, so an
+  // uncoded `SyntaxError` here is never the config's fault.
+  const unreadable =
+    code === 'ERR_UNKNOWN_FILE_EXTENSION' || (!code && error instanceof SyntaxError);
+  if (unreadable && TYPESCRIPT.has(extname(path).toLowerCase())) {
+    return 'Reading this config needs Node 22.18+, or a runtime that loads TypeScript itself (Bun, Deno, tsx).';
+  }
+
+  return null;
+}
 
 /**
  * Loads a config file as it sits on disk, leaving the runtime to deal with the
@@ -45,10 +52,10 @@ function loadModule(path: string) {
   try {
     return requireFresh(createRequire(path), path);
   } catch (error) {
-    const message = runtimeCannotRead(error)
-      ? `Failed to import module. ${HINT}`
-      : 'Failed to import module';
-    throw new Error(message, { cause: error });
+    const hint = diagnose(error, path);
+    throw new Error(hint ? `Failed to import module. ${hint}` : 'Failed to import module', {
+      cause: error,
+    });
   }
 }
 

--- a/packages/config/src/features/loader/resolve.test.ts
+++ b/packages/config/src/features/loader/resolve.test.ts
@@ -4,8 +4,6 @@ import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { resolveConfig } from './resolve.js';
 
 const cwd = process.cwd();
-// Inside the repo so the module loader's `createRequire` can resolve
-// `typescript` from the root node_modules when transpiling the config.
 const dir = mkdtempSync(join(cwd, '.tmp-loader-'));
 
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
@@ -13,7 +11,7 @@ beforeEach(() => process.chdir(dir));
 afterEach(() => process.chdir(cwd));
 
 describe('resolveConfig', () => {
-  it('loads and transpiles a TypeScript config file', () => {
+  it('loads a TypeScript config file', () => {
     writeFileSync(
       join(dir, 'saykit.config.ts'),
       `const config: { locales: string[] } = { locales: ['en', 'fr'] };\nexport default config;\n`,
@@ -22,10 +20,12 @@ describe('resolveConfig', () => {
     expect(config.locales).toEqual(['en', 'fr']);
   });
 
-  it('caches the transpiled module across calls', () => {
-    writeFileSync(join(dir, 'saykit.config.ts'), `export default { locales: ['de'] };\n`);
-    const first = resolveConfig() as { locales: string[] };
-    const second = resolveConfig() as { locales: string[] };
+  // Its own name: the runtime keys a loaded module by path, so reusing
+  // `saykit.config.ts` here would hand back the module the test above loaded.
+  it('returns the same config across calls', () => {
+    writeFileSync(join(dir, 'repeat.config.ts'), `export default { locales: ['de'] };\n`);
+    const first = resolveConfig('repeat') as { locales: string[] };
+    const second = resolveConfig('repeat') as { locales: string[] };
     expect(first).toEqual(second);
     expect(second.locales).toEqual(['de']);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,9 +194,6 @@ importers:
       picomatch:
         specifier: ^4.0.5
         version: 4.0.5
-      typescript:
-        specifier: '*'
-        version: 6.0.3
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/website/content/core-concepts/configuration.mdx
+++ b/website/content/core-concepts/configuration.mdx
@@ -42,7 +42,7 @@ relative imports, `import.meta.dirname` and `__dirname` all resolve against the 
 directory. A config is free to import a formatter or transformer from alongside it:
 
 ```ts title="saykit.config.ts"
-import { yaml } from './saykit/yaml-formatter.ts';
+import { yaml } from './yaml-formatter.ts';
 ```
 
 Reading TypeScript requires Node 22.18+, or a runtime that loads it itself (Bun, Deno, tsx). Note

--- a/website/content/core-concepts/configuration.mdx
+++ b/website/content/core-concepts/configuration.mdx
@@ -35,12 +35,20 @@ The first locale in `locales` is treated as the **source locale**: the language 
 
 The CLI and the build-tool plugins both load your config via `resolveConfig()` from
 `@saykit/config/features/loader`. It searches up from the current working directory for
-`saykit.config.{ts,mts,cts,js,mjs,cjs}` and transpiles TypeScript automatically.
+`saykit.config.{ts,mts,cts,js,mjs,cjs}` and loads the first match.
 
-Transpiled output is cached in `node_modules/.cache/saykit/config/` and invalidated when:
+The file is handed to the runtime as it sits on disk — nothing is copied, transpiled or cached — so
+relative imports, `import.meta.dirname` and `__dirname` all resolve against the config's own
+directory. A config is free to import a formatter or transformer from alongside it:
 
-- the config file's `mtime` changes, or
-- a `tsconfig.json` between the config and the workspace root changes.
+```ts title="saykit.config.ts"
+import { yaml } from './saykit/yaml-formatter.ts';
+```
+
+Reading TypeScript requires Node 22.18+, or a runtime that loads it itself (Bun, Deno, tsx). Note
+that relative specifiers need the real extension (`./yaml-formatter.ts`, not `.js`), and that
+enums, namespaces and parameter properties are not erasable syntax, so no runtime will accept
+them.
 
 ## Top-level schema
 

--- a/website/content/reference/api/config.mdx
+++ b/website/content/reference/api/config.mdx
@@ -189,7 +189,7 @@ import { resolveConfig } from '@saykit/config/features/loader';
 
 #### `resolveConfig(name?)`
 
-Search up from `process.cwd()` for `saykit.config.{ts,mts,cts,js,mjs,cjs}` (or `${name}.config.*`), transpile it if necessary, and return the validated `Config`.
+Search up from `process.cwd()` for `saykit.config.{ts,mts,cts,js,mjs,cjs}` (or `${name}.config.*`), load it, and return the validated `Config`.
 
 ```ts
 const config = resolveConfig(); // looks for saykit.config.*
@@ -202,7 +202,7 @@ Used by:
 - `unplugin-saykit`
 - `babel-plugin-saykit`
 
-Transpiled TS configs are cached in `node_modules/.cache/saykit/config/`, keyed by the config file's mtime and the workspace's `tsconfig.json` mtimes.
+The config is loaded from where it sits, so its relative imports and `import.meta.dirname` resolve against its own directory. Reading TypeScript requires Node 22.18+ or a runtime that loads it itself (Bun, Deno, tsx).
 
 ### `@saykit/config/features/messages`
 

--- a/website/content/reference/cli.mdx
+++ b/website/content/reference/cli.mdx
@@ -110,12 +110,7 @@ Keys that exist in the source but not in a locale file are deliberately left alo
 
 The CLI searches for `saykit.config.{ts,mts,cts,js,mjs,cjs}` starting from the current working directory and walking up the tree. The first match wins.
 
-TypeScript configs are transpiled on the fly with results cached under `node_modules/.cache/saykit/config/`. The cache is invalidated when:
-
-- the config file's `mtime` changes
-- any `tsconfig.json` between the config and the workspace root changes
-
-You usually don't need to think about this, the first run is a little slower, subsequent runs are fast.
+TypeScript configs are read by the runtime directly, which needs Node 22.18+ or a runtime that loads TypeScript itself (Bun, Deno, tsx). Nothing is written to disk, and a config can import from alongside it as normal — using the real extension, `./formatter.ts` rather than `./formatter.js`.
 
 ## Running from `package.json`
 


### PR DESCRIPTION
Closes #50.

## The bug

`@saykit/config` compiled every TypeScript config to
`node_modules/.cache/saykit/config/*.cjs` and `require`d it **from there**, so the loaded module
believed it lived in the cache directory. Every relative specifier resolved against that directory:

```
Error: Cannot find module './saykit/email-transformer.js'
Require stack:
- .../node_modules/.cache/saykit/config/8c626733dff3e99e.f534e2d42583d906.cjs
```

`__dirname`, `__filename` and `require.resolve` were wrong for the same reason, so reading a data
file next to the config failed too. Only bare specifiers worked, and only incidentally — Node walks
up from the cache directory and eventually reaches the project's `node_modules`. That forced custom
formatters and transformers to be reachable by package name, which is a lot of ceremony for a
twenty-line YAML formatter.

## The fix

Modern runtimes read TypeScript themselves, so hand them the file as it sits on disk. The entire
transpiling layer goes: the cache directory, the tsconfig lookup, the mtime keying, the pruning, the
compiler-API branch, the Node type-stripping branch, and the optional `typescript` peer dependency.
`module.ts` drops from 199 lines to 63, and the loader is now:

```ts
function loadModule(path: string) {
  try {
    return requireFresh(createRequire(path), path);
  } catch (error) {
    const message = runtimeCannotRead(error)
      ? `Failed to import module. ${HINT}`
      : 'Failed to import module';
    throw new Error(message, { cause: error });
  }
}
```

`runtimeCannotRead` exists only for the error message. Without it a user on an older Node gets a
bare `SyntaxError: Unexpected token ':'` pointing into their own config, which is a miserable way to
find out your runtime is too old; now they get the version requirement instead.

Configs can now import from alongside themselves:

```ts title="saykit.config.ts"
import { yaml } from './saykit/yaml-formatter.ts';
```

## Breaking

- **Node 22.18+**, or a runtime that loads TypeScript itself (Bun, Deno, tsx). Recorded in
  `engines.node`; released as a minor.
- **Relative specifiers need the real extension** — `./formatter.ts`, not `./formatter.js`. Nothing
  remaps them any more.
- **Enums, namespaces and parameter properties** in a config are out. They are not erasable syntax,
  so no runtime accepts them.
- **A config edited in the same process is not re-read.** Node keys ES modules by URL and never
  evicts them, so the mtime-keyed cache filename was buying invalidation as a side effect. In
  practice this means a dev server that restarts in-process after a `saykit.config.ts` edit keeps
  the old config until the process dies. Recoverable in ~10 lines without reintroducing the
  compiler (copy the source to a uniquely-named sibling `.ts` so the URL is fresh but the directory
  is not) if it turns out to bite.

## Tests

`module.test.ts` is rewritten around what the loader now promises: relative imports flat and
nested, reading a file via `import.meta.dirname`, nothing left behind on disk, a config's own error
surfacing untouched, and a readable message for non-erasable syntax. Two tests in `resolve.test.ts`
were writing different contents to the same `saykit.config.ts` and relied on the old cache for
isolation — the second now uses its own name, with a comment saying why.

Full suite passes (299), `pnpm check`, oxlint and oxfmt clean. Docs updated in
`core-concepts/configuration.mdx`, `reference/api/config.mdx` and `reference/cli.mdx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configuration files now load directly from the runtime, preserving relative imports and `import.meta.dirname` behaviour.
  - Config loading no longer creates transpilation or cache files.
  - Improved error messages identify unsupported TypeScript syntax and provide runtime guidance.

- **Bug Fixes**
  - Fixed relative imports and nested imports in configuration files.
  - Ensured errors from configuration files retain their original cause.

- **Documentation**
  - Updated configuration loading requirements, supported file extensions, and runtime guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->