### PR TITLE
Allow declaring catalogue messages on a bucket

### DIFF
--- a/.changeset/bucket-declared-messages.md
+++ b/.changeset/bucket-declared-messages.md
@@ -1,0 +1,5 @@
+---
+'@saykit/config': minor
+---
+
+Add a `messages` field to buckets for declaring catalogue entries that have no call site to extract from

--- a/examples/browser-extension/README.md
+++ b/examples/browser-extension/README.md
@@ -51,15 +51,21 @@ write the key by hand:
 { "name": "__MSG_extensionName__" }
 ```
 
-So the two strings the manifest references are given explicit ids:
+Extraction only ever sees JavaScript, and the manifest is not code, so nothing in `src/` would put
+those strings in the catalogue. They are declared on the bucket instead, where the record key _is_
+the id:
 
 ```ts
-say({ id: 'extensionName' })`Reading Time`;
+messages: {
+  extensionName: {
+    message: 'Reading Time',
+    comments: ["The extension's name, shown in the Chrome Web Store and toolbar."],
+  },
+},
 ```
 
-They live in `src/i18n.ts` for the sole reason that extraction only sees JavaScript — the manifest
-is not code, so nothing else would put those strings in the catalogue. Give an explicit id to any
-message that something outside your source has to name; let the rest stay hashed.
+Declare any string that a non-JavaScript artefact owns — a manifest, a store listing, an email
+subject — and let everything with a real call site stay hashed.
 
 ## Two i18n systems, one catalogue
 

--- a/examples/browser-extension/README.md
+++ b/examples/browser-extension/README.md
@@ -7,13 +7,13 @@ This is the example for **making SayKit write files in a layout something else a
 
 ## What it demonstrates
 
-| Concern                                                 | Where              |
-| ------------------------------------------------------- | ------------------ |
-| `json({ dialect: 'webextension' })`                     | `saykit.config.ts` |
-| `{locale}` used as a **directory**, not a filename      | `saykit.config.ts` |
-| Explicit `say({ id })` for keys the manifest references | `src/i18n.ts`      |
-| `chrome.i18n.getUILanguage()` + `say.match`             | `src/i18n.ts`      |
-| Keeping the catalogue out of the content script         | `src/content.ts`   |
+| Concern                                                         | Where              |
+| --------------------------------------------------------------- | ------------------ |
+| `json({ dialect: 'webextension' })`                             | `saykit.config.ts` |
+| `{locale}` used as a **directory**, not a filename              | `saykit.config.ts` |
+| Bucket-declared `messages` for the keys the manifest references | `saykit.config.ts` |
+| `chrome.i18n.getUILanguage()` + `say.match`                     | `src/i18n.ts`      |
+| Keeping the catalogue out of the content script                 | `src/content.ts`   |
 
 ## Writing straight into `_locales/`
 

--- a/examples/browser-extension/_locales/en/messages.json
+++ b/examples/browser-extension/_locales/en/messages.json
@@ -13,11 +13,11 @@
   },
   "extensionDescription": {
     "message": "Estimate how long a page will take to read.",
-    "x-saykit-references": ["src/i18n.ts:41"]
+    "description": "The extension's one-line store description."
   },
   "extensionName": {
     "message": "Reading Time",
-    "x-saykit-references": ["src/i18n.ts:38"]
+    "description": "The extension's name, shown in the Chrome Web Store and toolbar."
   },
   "Kg6WIx": {
     "message": "Reading time",

--- a/examples/browser-extension/saykit.config.ts
+++ b/examples/browser-extension/saykit.config.ts
@@ -17,6 +17,23 @@ export default defineConfig({
       output: '_locales/{locale}/messages.{extension}',
 
       /**
+       * `manifest.json` is not JavaScript, so nothing in `src/` would ever put
+       * its `__MSG_…__` strings in the catalogue. Declaring them here keeps them
+       * translated without a dummy module whose only job is to be scanned — and
+       * the record keys become the ids the manifest references.
+       */
+      messages: {
+        extensionName: {
+          message: 'Reading Time',
+          comments: ["The extension's name, shown in the Chrome Web Store and toolbar."],
+        },
+        extensionDescription: {
+          message: 'Estimate how long a page will take to read.',
+          comments: ["The extension's one-line store description."],
+        },
+      },
+
+      /**
        * The `webextension` dialect writes the `{ key: { message, description } }`
        * shape that `chrome.i18n` reads. Translator comments become `description`
        * — which is what the Chrome Web Store translation tooling shows to

--- a/examples/browser-extension/src/i18n.ts
+++ b/examples/browser-extension/src/i18n.ts
@@ -21,24 +21,4 @@ export function activateUiLocale() {
   return say;
 }
 
-/**
- * Two messages that also appear in `manifest.json`, and therefore need stable,
- * hand-written ids rather than content hashes. Everything else in this
- * extension is keyed by hash; these two are not, because `__MSG_extensionName__`
- * has to name something a human wrote down.
- *
- * They are declared here purely so extraction sees them — the manifest is not
- * JavaScript, so nothing else would put them in the catalogue.
- *
- * TODO: Create an easier way to add strings to the catalogue without having to
- * add them to code.
- */
-export const manifestStrings = {
-  // Translators: the extension's name, shown in the Chrome Web Store and toolbar.
-  name: () => say({ id: 'extensionName' })`Reading Time`,
-  // Translators: the extension's one-line store description.
-  description: () =>
-    say({ id: 'extensionDescription' })`Estimate how long a page will take to read.`,
-};
-
 export default say;

--- a/packages/config/src/features/workers/extract-worker.test.ts
+++ b/packages/config/src/features/workers/extract-worker.test.ts
@@ -81,11 +81,12 @@ describe('BucketExtractWorker.write', () => {
     ];
 
     await extract([
-      msg({ id: 'extensionName', message: 'Reading Time', references: ['src/app.ts:1'] }),
+      msg({ id: 'extensionName', message: 'Extracted Name', references: ['src/app.ts:1'] }),
     ]);
 
     const entries = readLocale('en');
     expect(entries).toHaveLength(1);
+    expect(entries[0]?.message).toBe('Reading Time');
     expect(entries[0]?.comments).toEqual(['The name']);
     // The call site still contributes its reference.
     expect(entries[0]?.references).toEqual(['src/app.ts:1']);

--- a/packages/config/src/features/workers/extract-worker.test.ts
+++ b/packages/config/src/features/workers/extract-worker.test.ts
@@ -84,11 +84,11 @@ describe('BucketExtractWorker.write', () => {
       msg({ id: 'extensionName', message: 'Reading Time', references: ['src/app.ts:1'] }),
     ]);
 
-    const [declared] = readLocale('en').filter((m) => m.id === 'extensionName');
-    expect(readLocale('en')).toHaveLength(1);
-    expect(declared.comments).toEqual(['The name']);
+    const entries = readLocale('en');
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.comments).toEqual(['The name']);
     // The call site still contributes its reference.
-    expect(declared.references).toEqual(['src/app.ts:1']);
+    expect(entries[0]?.references).toEqual(['src/app.ts:1']);
   });
 
   it('creates a header-only file for a locale that does not exist yet', async () => {

--- a/packages/config/src/features/workers/extract-worker.test.ts
+++ b/packages/config/src/features/workers/extract-worker.test.ts
@@ -30,6 +30,7 @@ beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'saykit-extract-'));
   bucket = {
     include: ['src/**/*.ts'],
+    messages: [],
     match: (id: string) => id.endsWith('.ts'),
     output: Object.assign(join(dir, '{locale}', 'messages.{extension}'), {
       match: (id: string) => id.endsWith('messages.json'),
@@ -62,6 +63,32 @@ describe('BucketExtractWorker.write', () => {
     expect(readLocale('en').map((m) => m.id)).toEqual(
       expect.arrayContaining(['greeting', 'farewell']),
     );
+  });
+
+  it('writes messages declared on the bucket even when no file yields them', async () => {
+    bucket.messages = [msg({ id: 'extensionName', message: 'Reading Time' })];
+
+    await extract([msg({ message: 'Hello', id: 'greeting' })]);
+
+    expect(readLocale('en').map((m) => m.id)).toEqual(
+      expect.arrayContaining(['extensionName', 'greeting']),
+    );
+  });
+
+  it('keeps a declared message authoritative when source also extracts its id', async () => {
+    bucket.messages = [
+      msg({ id: 'extensionName', message: 'Reading Time', comments: ['The name'] }),
+    ];
+
+    await extract([
+      msg({ id: 'extensionName', message: 'Reading Time', references: ['src/app.ts:1'] }),
+    ]);
+
+    const [declared] = readLocale('en').filter((m) => m.id === 'extensionName');
+    expect(readLocale('en')).toHaveLength(1);
+    expect(declared.comments).toEqual(['The name']);
+    // The call site still contributes its reference.
+    expect(declared.references).toEqual(['src/app.ts:1']);
   });
 
   it('creates a header-only file for a locale that does not exist yet', async () => {

--- a/packages/config/src/features/workers/extract-worker.ts
+++ b/packages/config/src/features/workers/extract-worker.ts
@@ -53,7 +53,8 @@ export class BucketExtractWorker extends BucketWorker {
       );
     await Promise.all(paths.map((p) => this.#indexPath(p)));
 
-    this.logger.info(`Total extracted messages: ${this.#indexedMessages.length}`);
+    const extracted = Array.from(this.#indexedMessagesByPath.values()).flat().length;
+    this.logger.info(`Total extracted messages: ${extracted}`);
   }
 
   async write() {

--- a/packages/config/src/features/workers/extract-worker.ts
+++ b/packages/config/src/features/workers/extract-worker.ts
@@ -18,7 +18,9 @@ function exists(path: string) {
 export class BucketExtractWorker extends BucketWorker {
   #indexedMessagesByPath = new Map<string, Message[]>();
   get #indexedMessages() {
-    return Array.from(this.#indexedMessagesByPath.values()).flat();
+    // Config-declared messages lead so their hand-written metadata wins the
+    // merge; extracted occurrences of the same id only contribute references.
+    return [...this.bucket.messages, ...Array.from(this.#indexedMessagesByPath.values()).flat()];
   }
 
   async #indexPath(path: string) {
@@ -45,6 +47,10 @@ export class BucketExtractWorker extends BucketWorker {
 
     const paths = await globBucket(this.bucket);
     this.logger.step(`Found ${paths.length} file(s)`);
+    if (this.bucket.messages.length)
+      this.logger.step(
+        `Including ${this.bucket.messages.length} message(s) declared in the config`,
+      );
     await Promise.all(paths.map((p) => this.#indexPath(p)));
 
     this.logger.info(`Total extracted messages: ${this.#indexedMessages.length}`);

--- a/packages/config/src/shapes.test.ts
+++ b/packages/config/src/shapes.test.ts
@@ -49,6 +49,52 @@ describe('Bucket schema', () => {
     expect(bucket.match('src/ignore/x.ts')).toBe(false);
   });
 
+  it('normalises declared messages into catalogue entries', () => {
+    const bucket = Bucket.parse({
+      include: ['src/**/*.ts'],
+      output: 'l/{locale}/m.{extension}',
+      messages: {
+        extensionName: 'Reading Time',
+        extensionDescription: {
+          message: 'Estimate how long a page will take to read.',
+          context: 'store',
+          comments: ['The one-line store description.'],
+        },
+      },
+      formatter,
+      transformer: transformer('a', '.ts'),
+    });
+
+    expect(bucket.messages).toEqual([
+      {
+        id: 'extensionName',
+        message: 'Reading Time',
+        translation: 'Reading Time',
+        context: undefined,
+        comments: [],
+        references: [],
+      },
+      {
+        id: 'extensionDescription',
+        message: 'Estimate how long a page will take to read.',
+        translation: 'Estimate how long a page will take to read.',
+        context: 'store',
+        comments: ['The one-line store description.'],
+        references: [],
+      },
+    ]);
+  });
+
+  it('declares no messages when the field is omitted', () => {
+    const bucket = Bucket.parse({
+      include: ['src/**/*.ts'],
+      output: 'l/{locale}/m.{extension}',
+      formatter,
+      transformer: transformer('a', '.ts'),
+    });
+    expect(bucket.messages).toEqual([]);
+  });
+
   it('combines an array of transformers, skipping non-matching ones', () => {
     const bucket = Bucket.parse({
       include: ['**/*'],

--- a/packages/config/src/shapes.ts
+++ b/packages/config/src/shapes.ts
@@ -27,11 +27,33 @@ export const Transformer = z.object({
 });
 export type Transformer = z.infer<typeof Transformer>;
 
+/**
+ * A message declared in the config rather than found in source. The shorthand
+ * is the source string; the object form adds the metadata a descriptor would
+ * otherwise carry.
+ */
+export const DeclaredMessage = z.string().or(
+  z.object({
+    message: z.string(),
+    context: z.string().optional(),
+    comments: z.string().array().optional(),
+  }),
+);
+export type DeclaredMessage = z.infer<typeof DeclaredMessage>;
+
 export const Bucket = z
   .object({
     include: z.string().array(),
     exclude: z.string().array().optional(),
     output: z.templateLiteral([z.string(), '{locale}', z.string(), '.{extension}']),
+    /**
+     * Messages that belong in the catalogue but have no call site to extract
+     * them from — strings owned by a non-JavaScript artefact such as a manifest,
+     * a store listing, or an email subject. Keyed by id, so the id is stable and
+     * hand-written by definition, and merged into every extraction alongside
+     * whatever the transformers find.
+     */
+    messages: z.record(z.string(), DeclaredMessage).optional(),
     formatter: Formatter,
     transformer: Transformer.transform((t) => [t])
       .or(Transformer.array())
@@ -48,6 +70,21 @@ export const Bucket = z
   })
   .transform((v) => ({
     ...v,
+    messages: Object.entries(v.messages ?? {}).map(([id, declared]): Message => {
+      const entry = typeof declared === 'string' ? { message: declared } : declared;
+      return {
+        id,
+        message: entry.message,
+        // Declaring a message declares the source string, so it is its own
+        // translation in the source locale, exactly as an extracted one is.
+        translation: entry.message,
+        context: 'context' in entry ? entry.context : undefined,
+        comments: ('comments' in entry ? entry.comments : undefined) ?? [],
+        // There is no call site to point a translator at — that is the whole
+        // reason the message is declared here.
+        references: [],
+      };
+    }),
     match: picomatch(v.include, { ignore: v.exclude }) as (id: string) => boolean,
     output: Object.assign(v.output, {
       match: picomatch(

--- a/website/content/core-concepts/configuration.mdx
+++ b/website/content/core-concepts/configuration.mdx
@@ -143,6 +143,11 @@ A bucket is a unit of "files in &rarr; translation file out". Most projects have
       type: '`${string}{locale}${string}{extension}`',
       required: true,
     },
+    messages: {
+      description:
+        'Messages declared here rather than extracted from source, keyed by id. Values are the source string, or an object with `message`, `context`, and `comments`.',
+      type: 'Record<string, string | { message: string; context?: string; comments?: string[] }>',
+    },
     formatter: {
       description: 'A Formatter that reads and writes the chosen translation file format.',
       type: 'Formatter',
@@ -173,6 +178,31 @@ output: 'src/locales/{locale}.{extension}';
 output: 'translations/{locale}/messages.{extension}';
 // → translations/en/messages.po, translations/fr/messages.po
 ```
+
+### Declared messages
+
+Extraction only sees messages that appear as macros in source files. When a string belongs in the catalogue but has no call site — a browser extension manifest, an app store listing, an email subject, database seed data — declare it on the bucket instead of writing a dummy module for the extractor to find.
+
+```ts
+messages: {
+  // Shorthand: the value is the source string.
+  extensionName: 'Reading Time',
+
+  // Long form, for the metadata a descriptor would otherwise carry.
+  extensionDescription: {
+    message: 'Estimate how long a page will take to read.',
+    context: 'store',
+    comments: ["The extension's one-line store description."],
+  },
+},
+```
+
+Each key is the message id, so declared strings always have stable, hand-written keys rather than content hashes — which is exactly what a manifest needs when it names one. They are merged into the catalogue on every `saykit extract`, alongside everything the transformers find. If a source file happens to use the same id, the declaration wins on text and comments, and the call site still contributes its source reference.
+
+<Callout type="info">
+  Declared messages have no call site, so they are written without source references. Use `comments`
+  to tell translators where the string actually shows up.
+</Callout>
 
 ### Multiple transformers
 

--- a/website/content/reference/api/config.mdx
+++ b/website/content/reference/api/config.mdx
@@ -81,6 +81,11 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
       type: '`${string}{locale}${string}{extension}`',
       required: true,
     },
+    messages: {
+      description:
+        'Messages declared in the config rather than extracted from source, keyed by id. Values are the source string, or `{ message, context?, comments? }`.',
+      type: 'Record<string, string | { message: string; context?: string; comments?: string[] }>',
+    },
     formatter: {
       description: 'The Formatter for this bucket.',
       type: 'Formatter',


### PR DESCRIPTION
@
Closes #55.

Takes option 1 from the issue: a `messages` record on the bucket, keyed by id. Values are either the source string or `{ message, context?, comments? }`. The bucket schema normalises them into `Message[]`, and the extract worker merges them ahead of whatever the transformers find — so a declaration wins on text and comments, while a source file that happens to use the same id still contributes its reference. Declared messages carry no source references, since having no call site is the entire point.

`examples/browser-extension` drops the `manifestStrings` dummy object and declares the two manifest strings in its config instead. The re-extracted catalogue has the same ten keys as before, and the translator comments now actually land in `description` — they did not previously, because they sat on object properties rather than on the `say()` calls.

Docs: a "Declared messages" section in the configuration guide, the field added to both bucket type tables, and the example README updated.

Not included: documenting custom transformers as the escape hatch for non-JS files (option 3 in the issue). `messages` covers static strings; a `.email`-style transformer is still the better answer when the artefact has many strings or its own structure. Worth a follow-up if you want that spelled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring translation messages directly in bucket configuration.
  * Supports stable message IDs, source text, context, and translator comments.
  * Declared messages are included in generated catalogues, including entries without source-code call sites.
  * Configured messages take precedence while still incorporating extracted references.

* **Documentation**
  * Added configuration guidance and examples for declared messages, including browser extension manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->