### PR TITLE
ci: type-check examples in pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -78,9 +78,13 @@ jobs:
     name: Example Type Checking
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: ./.github/actions/node

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,6 +9,7 @@ on:
       - 'turbo.json'
       - 'packages/**/src/**'
       - 'packages/**/package.json'
+      - 'examples/**'
       - '.changeset/**'
       - '.github/workflows/pipeline.yml'
   pull_request:
@@ -21,6 +22,7 @@ on:
       - 'turbo.json'
       - 'packages/**/src/**'
       - 'packages/**/package.json'
+      - 'examples/**'
       - '.changeset/**'
       - '.github/workflows/pipeline.yml'
   workflow_dispatch:
@@ -71,6 +73,26 @@ jobs:
 
       - name: Run the type checker
         run: pnpm check --filter "./packages/*"
+
+  examples:
+    name: Example Type Checking
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: ./.github/actions/node
+
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: packages
+
+      - name: Type-check examples
+        run: pnpm --filter "./examples/*" check
 
   lint:
     name: Linting
@@ -133,7 +155,7 @@ jobs:
 
   process:
     name: Processing Changesets
-    needs: [check, lint, test]
+    needs: [check, examples, lint, test]
     runs-on: ubuntu-latest
     outputs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}


### PR DESCRIPTION
## Summary
- add `examples/**` to the pipeline path filters
- add an examples type-check job that runs after package build and checks `./examples/*`
- make main-branch changeset processing wait for the examples check

Fixes #56

## Verification
- `npm exec --yes pnpm@11.17.0 -- install --frozen-lockfile`
- `npm exec --yes pnpm@11.17.0 -- build`
- `npm exec --yes pnpm@11.17.0 -- --filter "./examples/*" check`
- `npm exec --yes pnpm@11.17.0 -- check --filter "./packages/*"`
- `npm exec --yes pnpm@11.17.0 -- lint`
- `git diff --check`

## Notes
- Kept this to the lightweight examples type-check only; no native builds, deploys, or extension loading.
- `pnpm install` warns about saykit bins before package build because the config package dist is not generated yet; the workflow builds packages before the examples job downloads dist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated type-checking for example packages.
  * Example-package checks now run when example files change.
  * Release processing waits for example checks to complete alongside existing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->