### PR TITLE
fix: add JSX message source references

### DIFF
--- a/.changeset/loud-files-fold.md
+++ b/.changeset/loud-files-fold.md
@@ -1,0 +1,5 @@
+---
+"@saykit/transform-jsx": patch
+---
+
+Add JSX message source references to parser

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -25,6 +25,19 @@ describe('createJsxTransformer.extract', () => {
     const message = messages.find((m) => m.id === 'greeting');
     expect(message).toBeDefined();
     expect(message!.message).toContain('Hello');
+    expect(message!.references).toEqual(['file.tsx:1']);
+  });
+
+  it('extracts a JSX choice element reference', () => {
+    const [message] = transformer.extract(
+      'const x = <Say.Plural _={count} one="# item" other="# items" />;',
+      'file.tsx',
+    );
+    expect(message!.message).toBe(`{count, plural,
+  one {# item}
+  other {# items}
+}`);
+    expect(message!.references).toEqual(['file.tsx:1']);
   });
 
   it('extracts a tagged-template message alongside JSX', () => {

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -169,7 +169,8 @@ export function parseJSXElement(element: t.JSXElement, fallback?: boolean): Mess
 }
 
 function getReferences(node: t.Node) {
-  return node.loc ? [`${node.loc.filename}:${node.loc.start.line}`] : [];
+  if (!node.loc?.filename) return [];
+  return [`${node.loc.filename}:${node.loc.start.line}`];
 }
 
 function getAttributeNameAsString(attribute: t.JSXAttribute) {

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -48,7 +48,7 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
   return new CompositeMessage(
     { id: descriptorId, context: descriptorContext },
     [],
-    [],
+    getReferences(element),
     children,
     accessor as t.Expression,
     whitespace,
@@ -115,7 +115,7 @@ export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeM
     return new CompositeMessage(
       { id: descriptorId, context: descriptorContext },
       [],
-      [],
+      getReferences(element),
       [choice],
       accessor as t.Expression,
     );
@@ -166,6 +166,10 @@ export function parseJSXElement(element: t.JSXElement, fallback?: boolean): Mess
   // `Say` container), so the wrapped message is never null.
   const wrapped = parseJSXElement(fake, true)!;
   return new ElementMessage(AUTO_INCREMENT_IDENTIFIER, [wrapped], element);
+}
+
+function getReferences(node: t.Node) {
+  return node.loc ? [`${node.loc.filename}:${node.loc.start.line}`] : [];
 }
 
 function getAttributeNameAsString(attribute: t.JSXAttribute) {


### PR DESCRIPTION
## Summary
- add source references for JSX `<Say>` container messages
- add source references for JSX choice messages like `<Say.Plural />`
- cover both paths in transform-jsx extraction tests

## Test plan
- `pnpm --filter @saykit/config build`
- `pnpm --filter @saykit/transform-js build`
- `pnpm --filter @saykit/transform-jsx check`
- `pnpm vitest packages/transform-jsx/src/index.test.ts`
- `pnpm --filter @saykit/transform-jsx build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extracted JSX messages now include source file and line references.
  * Added reference tracking for JSX choice elements, including plural messages.
  * Improved extracted message metadata when source location details are available.
* **Tests**
  * Extended JSX extraction test coverage to assert reference arrays and formatted plural ICU output.
* **Chores**
  * Added a patch-level changeset entry for the updated JSX reference behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->