### PR TITLE
fix: match JSX text whitespace

### DIFF
--- a/.changeset/fresh-pugs-kiss.md
+++ b/.changeset/fresh-pugs-kiss.md
@@ -1,0 +1,5 @@
+---
+"@saykit/transform-jsx": patch
+---
+
+Fix JSX extraction so punctuation after rich-text elements does not gain a leading space.

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -2,6 +2,7 @@ import { parseExpression } from '@babel/parser';
 import * as t from '@babel/types';
 import {
   ArgumentMessage,
+  assignSequenceIdentifiers,
   AUTO_INCREMENT_IDENTIFIER,
   ChoiceMessage,
   CompositeMessage,
@@ -44,6 +45,41 @@ describe('parseJSXContainerElement', () => {
     expect((result!.children[0] as LiteralMessage).text).toBe('Hello, world!');
   });
 
+  it('matches JSX whitespace around multiline element boundaries', () => {
+    const result = parser.parseJSXContainerElement(jsx`
+      <Say>
+        Kiai Security - Only authorize apps you trust. Report malicious
+        integrations in
+        <a href="https://discord.gg/example">our support server</a>
+        .
+      </Say>
+    `);
+    assignSequenceIdentifiers(result!);
+    expect(result!.toICUString()).toBe(
+      'Kiai Security - Only authorize apps you trust. Report malicious integrations in<0>our support server</0>.',
+    );
+  });
+
+  it('does not insert implicit spaces around multiline elements', () => {
+    const result = parser.parseJSXContainerElement(jsx`
+      <Say>
+        Hello
+        <strong>brave</strong>
+        world!
+      </Say>
+    `);
+    assignSequenceIdentifiers(result!);
+    expect(result!.toICUString()).toBe('Hello<0>brave</0>world!');
+  });
+
+  it('preserves explicit same-line spaces around elements', () => {
+    const result = parser.parseJSXContainerElement(
+      jsx`<Say>Hello <strong>brave</strong> world!</Say>`,
+    );
+    assignSequenceIdentifiers(result!);
+    expect(result!.toICUString()).toBe('Hello <0>brave</0> world!');
+  });
+
   it('parses expression children as ArgumentMessage', () => {
     const result = parser.parseJSXContainerElement(jsx`<Say>{name}</Say>`);
     expect(result!.children[0]).toBeInstanceOf(ArgumentMessage);
@@ -69,8 +105,19 @@ describe('parseJSXContainerElement', () => {
     expect(result!.descriptor).toEqual({ id: 'msg', context: 'nav' });
   });
 
-  it('drops text children that are only whitespace', () => {
+  it('preserves same-line whitespace-only text children', () => {
     const result = parser.parseJSXContainerElement(jsx`<Say>{name}   </Say>`);
+    expect(result!.children).toHaveLength(2);
+    expect(result!.children[0]).toBeInstanceOf(ArgumentMessage);
+    expect(result!.children[1]).toEqual(new LiteralMessage('   '));
+  });
+
+  it('drops multiline whitespace-only text children', () => {
+    const result = parser.parseJSXContainerElement(jsx`
+      <Say>
+        {name}
+      </Say>
+    `);
     expect(result!.children).toHaveLength(1);
     expect(result!.children[0]).toBeInstanceOf(ArgumentMessage);
   });

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -15,11 +15,9 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
   if (!processed) return null;
   const [accessor] = processed;
 
-  const children = element.children.reduce<Message[]>((p, c, i, a) => {
+  const children = element.children.reduce<Message[]>((p, c) => {
     if (t.isJSXText(c)) {
-      let text = c.value.replace(/\s+/g, ' ');
-      if (i === 0) text = text.trimStart();
-      if (i === a.length - 1) text = text.trimEnd();
+      const text = normalizeJSXText(c.value);
       if (text) p.push(new LiteralMessage(text));
     }
 
@@ -122,6 +120,32 @@ export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeM
   }
 
   return null;
+}
+
+function normalizeJSXText(value: string) {
+  const lines = value.split(/\r\n|\n|\r/);
+  let lastNonEmptyLine = 0;
+
+  for (const [index, line] of lines.entries()) {
+    if (/[^ \t]/.test(line)) lastNonEmptyLine = index;
+  }
+
+  let text = '';
+
+  for (const [index, line] of lines.entries()) {
+    const isFirstLine = index === 0;
+    const isLastLine = index === lines.length - 1;
+    const isLastNonEmptyLine = index === lastNonEmptyLine;
+    let trimmedLine = line.replace(/\t/g, ' ');
+
+    if (!isFirstLine) trimmedLine = trimmedLine.replace(/^ +/, '');
+    if (!isLastLine) trimmedLine = trimmedLine.replace(/ +$/, '');
+    if (!trimmedLine) continue;
+
+    text += isLastNonEmptyLine ? trimmedLine : `${trimmedLine} `;
+  }
+
+  return text;
 }
 
 function processJSXOpeningElement(element: t.JSXOpeningElement): [t.Node, string | null] | null {


### PR DESCRIPTION
## Summary
- Normalize JSX text nodes in the JSX transformer using React/Babel-style JSX whitespace handling
- Preserve explicit same-line whitespace while avoiding implicit whitespace around multiline JSX element boundaries
- Add parser regression coverage and a patch changeset for `@saykit/transform-jsx`
- Definitely didn't put a Kiai reference in

## Tests
- `pnpm build`
- `pnpm check`
- `pnpm test -- --run`
