### PR TITLE
Add say-tag for naming JSX placeholders

### DIFF
--- a/.changeset/lucky-cases-shake.md
+++ b/.changeset/lucky-cases-shake.md
@@ -1,0 +1,6 @@
+---
+"@saykit/transform-jsx": minor
+"@saykit/config": minor
+---
+
+Add `say-tag` to name JSX placeholders, and extract childless elements as self-closing tags

--- a/.changeset/lucky-cases-shake.md
+++ b/.changeset/lucky-cases-shake.md
@@ -1,6 +1,7 @@
 ---
 "@saykit/transform-jsx": minor
 "@saykit/config": minor
+"@saykit/react": minor
 ---
 
-Add `say-tag` to name JSX placeholders, and extract childless elements as self-closing tags
+Add `say-tag` to name JSX placeholders, extract childless elements as self-closing tags, and compile message values behind an underscore so no name is reserved

--- a/examples/react/src/components/task-card.tsx
+++ b/examples/react/src/components/task-card.tsx
@@ -31,13 +31,16 @@ export function TaskCard({ task }: { task: Task }) {
 
       <p className="card__meta">
         {/*
-          A JSX child inside `<Say>` is extracted as a positional `<0>` tag, so a
-          translator can move the emphasised name anywhere in the sentence
-          without touching markup. The element itself never enters the catalogue.
+          A JSX child inside `<Say>` is extracted as a tag, so a translator can
+          move the emphasised name anywhere in the sentence without touching
+          markup. The element itself never enters the catalogue. `say-tag`
+          names that tag `<bold>` instead of a positional `<0>` — describe what
+          the tag does, not what it wraps. The attribute is stripped at build
+          time and never reaches the DOM.
         */}
         {task.assignee ? (
           <Say>
-            Assigned to <strong>{task.assignee}</strong>
+            Assigned to <strong say-tag="bold">{task.assignee}</strong>
           </Say>
         ) : (
           <Say>Nobody is on this yet</Say>

--- a/examples/react/src/locales/en.po
+++ b/examples/react/src/locales/en.po
@@ -12,7 +12,7 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: saykit\n"
 
-#: src/components/task-card.tsx:53
+#: src/components/task-card.tsx:56
 msgid ""
 "{0, plural,\n"
 "  =0 {All subtasks done}\n"
@@ -38,7 +38,7 @@ msgstr ""
 "  other {# days overdue}\n"
 "}"
 
-#: src/components/task-card.tsx:63
+#: src/components/task-card.tsx:66
 msgid ""
 "{0, plural,\n"
 "  one {# unresolved comment}\n"
@@ -108,9 +108,9 @@ msgstr ""
 "  other {# tasks still open}\n"
 "}"
 
-#: src/components/task-card.tsx:39
-msgid "Assigned to <0>{1}</0>"
-msgstr "Assigned to <0>{1}</0>"
+#: src/components/task-card.tsx:42
+msgid "Assigned to <bold>{0}</bold>"
+msgstr "Assigned to <bold>{0}</bold>"
 
 #: src/components/task-card.tsx:9
 msgid "Due today"
@@ -120,7 +120,7 @@ msgstr "Due today"
 msgid "Language"
 msgstr "Language"
 
-#: src/components/task-card.tsx:43
+#: src/components/task-card.tsx:46
 msgid "Nobody is on this yet"
 msgstr "Nobody is on this yet"
 

--- a/packages/config/src/features/messages/convert.test.ts
+++ b/packages/config/src/features/messages/convert.test.ts
@@ -29,6 +29,12 @@ describe('convertMessageToIcu', () => {
       .toMatchInlineSnapshot('"<0>Hello world!</0>"');
   });
 
+  it('should generate childless element messages as self-closing', () => {
+    const message = new ElementMessage('icon', [], dummy);
+    expect(convertMessageToIcu(message)) //
+      .toMatchInlineSnapshot('"<icon/>"');
+  });
+
   it('should generate choice messages with numeric identifiers as `=n`', () => {
     const message = new ChoiceMessage(
       'plural',

--- a/packages/config/src/features/messages/convert.test.ts
+++ b/packages/config/src/features/messages/convert.test.ts
@@ -35,6 +35,16 @@ describe('convertMessageToIcu', () => {
       .toMatchInlineSnapshot('"<icon/>"');
   });
 
+  it('should keep element messages paired when a child renders to nothing', () => {
+    const message = new ElementMessage(
+      'bold',
+      [new CompositeMessage({}, [], [], [], dummy)],
+      dummy,
+    );
+    expect(convertMessageToIcu(message)) //
+      .toMatchInlineSnapshot('"<bold></bold>"');
+  });
+
   it('should generate choice messages with numeric identifiers as `=n`', () => {
     const message = new ChoiceMessage(
       'plural',

--- a/packages/config/src/features/messages/convert.ts
+++ b/packages/config/src/features/messages/convert.ts
@@ -17,10 +17,12 @@ export function convertMessageToIcu(message: Message) {
         return `{${String(message.identifier)}}`;
 
       case message instanceof ElementMessage: {
-        const children = message.children.map((m) => internalConvertMessageToIcu(m)).join('');
         // A childless element is self-closing, so a translator has nowhere to
-        // insert content that the element never expected.
-        if (!children) return `<${String(message.identifier)}/>`;
+        // insert content that the element never expected. This tracks the
+        // source: an element written as a pair stays a pair, even when its
+        // children happen to render to nothing.
+        if (message.children.length === 0) return `<${String(message.identifier)}/>`;
+        const children = message.children.map((m) => internalConvertMessageToIcu(m)).join('');
         return `<${String(message.identifier)}>${children}</${String(message.identifier)}>`;
       }
 

--- a/packages/config/src/features/messages/convert.ts
+++ b/packages/config/src/features/messages/convert.ts
@@ -18,6 +18,9 @@ export function convertMessageToIcu(message: Message) {
 
       case message instanceof ElementMessage: {
         const children = message.children.map((m) => internalConvertMessageToIcu(m)).join('');
+        // A childless element is self-closing, so a translator has nowhere to
+        // insert content that the element never expected.
+        if (!children) return `<${String(message.identifier)}/>`;
         return `<${String(message.identifier)}>${children}</${String(message.identifier)}>`;
       }
 

--- a/packages/config/src/features/messages/identifier.test.ts
+++ b/packages/config/src/features/messages/identifier.test.ts
@@ -81,7 +81,33 @@ describe('assignSequenceIdentifiers', () => {
       null,
     );
     expect(() => assignSequenceIdentifiers(message)).toThrow(
-      "Duplicate element tag 'link', give each element in a message its own tag",
+      "Duplicate element tag 'link', give each element in a message its own tag unless they are identical",
+    );
+  });
+
+  it('allows two elements to share a tag when they are equivalent', () => {
+    const message = new CompositeMessage(
+      {},
+      [],
+      [],
+      [new ElementMessage('link', [], 'a'), new ElementMessage('link', [], 'a')],
+      null,
+    );
+    expect(() =>
+      assignSequenceIdentifiers(message, { current: 0 }, (a, b) => a === b),
+    ).not.toThrow();
+  });
+
+  it('throws when elements sharing a tag are not equivalent', () => {
+    const message = new CompositeMessage(
+      {},
+      [],
+      [],
+      [new ElementMessage('link', [], 'a'), new ElementMessage('link', [], 'b')],
+      null,
+    );
+    expect(() => assignSequenceIdentifiers(message, { current: 0 }, (a, b) => a === b)).toThrow(
+      "Duplicate element tag 'link'",
     );
   });
 

--- a/packages/config/src/features/messages/identifier.test.ts
+++ b/packages/config/src/features/messages/identifier.test.ts
@@ -64,6 +64,51 @@ describe('assignSequenceIdentifiers', () => {
     expect(value.identifier).toBe('0');
   });
 
+  it('skips sequence numbers already taken by an explicit identifier', () => {
+    const tagged = new ElementMessage('0', [], null);
+    const auto = new ArgumentMessage(AUTO_INCREMENT_IDENTIFIER, null);
+    assignSequenceIdentifiers(new CompositeMessage({}, [], [], [tagged, auto], null));
+    expect(tagged.identifier).toBe('0');
+    expect(auto.identifier).toBe('1');
+  });
+
+  it('throws when two elements share a tag', () => {
+    const message = new CompositeMessage(
+      {},
+      [],
+      [],
+      [new ElementMessage('link', [], null), new ElementMessage('link', [], null)],
+      null,
+    );
+    expect(() => assignSequenceIdentifiers(message)).toThrow(
+      "Duplicate element tag 'link', give each element in a message its own tag",
+    );
+  });
+
+  it('allows two arguments to share an identifier', () => {
+    const message = new CompositeMessage(
+      {},
+      [],
+      [],
+      [new ArgumentMessage('total', null), new ArgumentMessage('total', null)],
+      null,
+    );
+    expect(() => assignSequenceIdentifiers(message)).not.toThrow();
+  });
+
+  it('throws when an element tag collides with an argument', () => {
+    const message = new CompositeMessage(
+      {},
+      [],
+      [],
+      [new ElementMessage('total', [], null), new ArgumentMessage('total', null)],
+      null,
+    );
+    expect(() => assignSequenceIdentifiers(message)).toThrow(
+      "Element tag 'total' collides with an argument of the same name",
+    );
+  });
+
   it('leaves a literal message unchanged', () => {
     const literal = new LiteralMessage('hi');
     expect(() => assignSequenceIdentifiers(literal)).not.toThrow();

--- a/packages/config/src/features/messages/identifier.ts
+++ b/packages/config/src/features/messages/identifier.ts
@@ -8,8 +8,19 @@ import {
 
 export const AUTO_INCREMENT_IDENTIFIER = Symbol('auto-increment');
 
-export function assignSequenceIdentifiers(message: Message, sequence = { current: 0 }) {
-  const reserved = collectAssignedIdentifiers(message);
+/**
+ * Decides whether two elements sharing a tag are the same element, and so may
+ * share it. Only the syntax that produced them can answer that, so the caller
+ * supplies the comparison; by default no two elements are interchangeable.
+ */
+export type ElementEquivalence = (a: any, b: any) => boolean;
+
+export function assignSequenceIdentifiers(
+  message: Message,
+  sequence = { current: 0 },
+  equivalent: ElementEquivalence = () => false,
+) {
+  const reserved = collectAssignedIdentifiers(message, equivalent);
 
   function next() {
     let identifier = `${sequence.current++}`;
@@ -40,22 +51,24 @@ export function assignSequenceIdentifiers(message: Message, sequence = { current
  * Collect the identifiers already assigned before this pass runs, so generated
  * sequence numbers never shadow an explicit one (e.g. an element tagged `0`).
  *
- * Every element in a message needs its own tag: they each compile to their own
- * prop, and a translator has to be able to tell them apart. Two arguments may
- * legitimately share an identifier, though — the same variable interpolated
- * twice is one value — so only elements are checked for repeats.
+ * Elements that differ need their own tag: they each compile to their own prop,
+ * and a translator has to be able to tell them apart. Repeats are fine when
+ * nothing distinguishes them — two identical elements are one prop, the same
+ * way the same variable interpolated twice is one value — so arguments are
+ * never checked and elements only when they are not equivalent.
  */
-function collectAssignedIdentifiers(message: Message) {
-  const tags = new Set<string>();
+function collectAssignedIdentifiers(message: Message, equivalent: ElementEquivalence) {
+  const tags = new Map<string, ElementMessage>();
   const values = new Set<string>();
 
   function walk(message: Message) {
     if (message instanceof ElementMessage && typeof message.identifier === 'string') {
-      if (tags.has(message.identifier))
+      const previous = tags.get(message.identifier);
+      if (previous && !equivalent(previous.expression, message.expression))
         throw new Error(
-          `Duplicate element tag '${message.identifier}', give each element in a message its own tag`,
+          `Duplicate element tag '${message.identifier}', give each element in a message its own tag unless they are identical`,
         );
-      tags.add(message.identifier);
+      tags.set(message.identifier, message);
     }
     if (
       (message instanceof ArgumentMessage || message instanceof ChoiceMessage) &&
@@ -69,9 +82,9 @@ function collectAssignedIdentifiers(message: Message) {
 
   walk(message);
 
-  for (const tag of tags)
+  for (const tag of tags.keys())
     if (values.has(tag))
       throw new Error(`Element tag '${tag}' collides with an argument of the same name`);
 
-  return new Set([...tags, ...values]);
+  return new Set([...tags.keys(), ...values]);
 }

--- a/packages/config/src/features/messages/identifier.ts
+++ b/packages/config/src/features/messages/identifier.ts
@@ -9,19 +9,69 @@ import {
 export const AUTO_INCREMENT_IDENTIFIER = Symbol('auto-increment');
 
 export function assignSequenceIdentifiers(message: Message, sequence = { current: 0 }) {
-  if (
-    message instanceof ArgumentMessage ||
-    message instanceof ElementMessage ||
-    message instanceof ChoiceMessage
-  )
-    if (message.identifier === AUTO_INCREMENT_IDENTIFIER)
-      message.identifier = `${sequence.current++}`;
-  if (message instanceof CompositeMessage || message instanceof ElementMessage)
-    for (const child of message.children) assignSequenceIdentifiers(child, sequence);
-  if (message instanceof ChoiceMessage)
-    for (const branch of message.branches) {
-      if (branch.identifier === AUTO_INCREMENT_IDENTIFIER)
-        branch.identifier = `${sequence.current++}`;
-      assignSequenceIdentifiers(branch.value, sequence);
+  const reserved = collectAssignedIdentifiers(message);
+
+  function next() {
+    let identifier = `${sequence.current++}`;
+    while (reserved.has(identifier)) identifier = `${sequence.current++}`;
+    return identifier;
+  }
+
+  function walk(message: Message) {
+    if (
+      message instanceof ArgumentMessage ||
+      message instanceof ElementMessage ||
+      message instanceof ChoiceMessage
+    )
+      if (message.identifier === AUTO_INCREMENT_IDENTIFIER) message.identifier = next();
+    if (message instanceof CompositeMessage || message instanceof ElementMessage)
+      for (const child of message.children) walk(child);
+    if (message instanceof ChoiceMessage)
+      for (const branch of message.branches) {
+        if (branch.identifier === AUTO_INCREMENT_IDENTIFIER) branch.identifier = next();
+        walk(branch.value);
+      }
+  }
+
+  walk(message);
+}
+
+/**
+ * Collect the identifiers already assigned before this pass runs, so generated
+ * sequence numbers never shadow an explicit one (e.g. an element tagged `0`).
+ *
+ * Every element in a message needs its own tag: they each compile to their own
+ * prop, and a translator has to be able to tell them apart. Two arguments may
+ * legitimately share an identifier, though — the same variable interpolated
+ * twice is one value — so only elements are checked for repeats.
+ */
+function collectAssignedIdentifiers(message: Message) {
+  const tags = new Set<string>();
+  const values = new Set<string>();
+
+  function walk(message: Message) {
+    if (message instanceof ElementMessage && typeof message.identifier === 'string') {
+      if (tags.has(message.identifier))
+        throw new Error(
+          `Duplicate element tag '${message.identifier}', give each element in a message its own tag`,
+        );
+      tags.add(message.identifier);
     }
+    if (
+      (message instanceof ArgumentMessage || message instanceof ChoiceMessage) &&
+      typeof message.identifier === 'string'
+    )
+      values.add(message.identifier);
+    if (message instanceof CompositeMessage || message instanceof ElementMessage)
+      for (const child of message.children) walk(child);
+    if (message instanceof ChoiceMessage) for (const branch of message.branches) walk(branch.value);
+  }
+
+  walk(message);
+
+  for (const tag of tags)
+    if (values.has(tag))
+      throw new Error(`Element tag '${tag}' collides with an argument of the same name`);
+
+  return new Set([...tags, ...values]);
 }

--- a/packages/integration-react/src/runtime/index.test.ts
+++ b/packages/integration-react/src/runtime/index.test.ts
@@ -40,9 +40,10 @@ describe('Say', () => {
     };
     expect(props.html).toBe('<name/> world');
     expect(props.whitespace).toBe(false);
-    // The descriptor passed to `say.call` has the value props unprefixed and
-    // the `whitespace` prop removed.
-    expect(call).toHaveBeenCalledWith(expect.objectContaining({ id: 'greet', name: bold }));
+    // The descriptor passed to `say.call` is exactly the message id and the
+    // value props unprefixed, so a prefixed key or a renderer prop leaking
+    // into it fails here rather than reaching the runtime.
+    expect(call).toHaveBeenCalledWith({ id: 'greet', name: bold });
 
     // A slot that maps to a valid element clones it; other slots pass the tag through.
     const resolved = props.components('name') as (p: object) => ReactElement;
@@ -71,9 +72,10 @@ describe('Say', () => {
       whitespace?: boolean;
       components: (tag?: string) => unknown;
     };
-    // The real id still reaches `say.call`, and the flag still reaches the
-    // renderer, while both tags resolve to their elements.
-    expect(call).toHaveBeenCalledWith(expect.objectContaining({ id: 'greet' }));
+    // The real id still reaches `say.call` and the tag named after it does not
+    // displace it, while a tag named `whitespace` is a value like any other and
+    // the flag itself still reaches the renderer.
+    expect(call).toHaveBeenCalledWith({ id: 'greet', whitespace: bold });
     expect(props.whitespace).toBe(false);
     expect(typeof props.components('id')).toBe('function');
     expect(typeof props.components('whitespace')).toBe('function');

--- a/packages/integration-react/src/runtime/index.test.ts
+++ b/packages/integration-react/src/runtime/index.test.ts
@@ -29,7 +29,7 @@ describe('Say', () => {
     const element = (Say as (p: unknown) => ReactElement)({
       id: 'greet',
       whitespace: false,
-      name: bold,
+      _name: bold,
     });
 
     expect(element.type).toBe(Renderer);
@@ -40,8 +40,8 @@ describe('Say', () => {
     };
     expect(props.html).toBe('<name/> world');
     expect(props.whitespace).toBe(false);
-    // The descriptor passed to `say.call` has JSX-safe keys resolved and the
-    // `whitespace` prop removed.
+    // The descriptor passed to `say.call` has the value props unprefixed and
+    // the `whitespace` prop removed.
     expect(call).toHaveBeenCalledWith(expect.objectContaining({ id: 'greet', name: bold }));
 
     // A slot that maps to a valid element clones it; other slots pass the tag through.
@@ -49,10 +49,34 @@ describe('Say', () => {
     expect(typeof resolved).toBe('function');
     expect(isValidElement(resolved({}))).toBe(true);
     expect(props.components('missing')).toBe('missing');
-    // `id` is a string, not an element, so it also passes through as the tag.
+    // The message id is not a value, so nothing resolves for it as a tag.
     expect(props.components('id')).toBe('id');
     // Called with no tag, it returns the (undefined) tag.
     expect(props.components()).toBeUndefined();
+  });
+
+  it('lets a value be named after one of Say’s own props', () => {
+    const call = vi.fn(() => '<id/> and <whitespace/>');
+    globalThis.GET_SAY = () => ({ call });
+
+    const bold = createElement('b', null, 'Ada');
+    const element = (Say as (p: unknown) => ReactElement)({
+      id: 'greet',
+      whitespace: false,
+      _id: bold,
+      _whitespace: bold,
+    });
+
+    const props = element.props as {
+      whitespace?: boolean;
+      components: (tag?: string) => unknown;
+    };
+    // The real id still reaches `say.call`, and the flag still reaches the
+    // renderer, while both tags resolve to their elements.
+    expect(call).toHaveBeenCalledWith(expect.objectContaining({ id: 'greet' }));
+    expect(props.whitespace).toBe(false);
+    expect(typeof props.components('id')).toBe('function');
+    expect(typeof props.components('whitespace')).toBe('function');
   });
 
   it('exposes Plural, Ordinal and Select macros that throw', () => {

--- a/packages/integration-react/src/runtime/index.ts
+++ b/packages/integration-react/src/runtime/index.ts
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import type { Disallow, NumeralOptions, SelectOptions } from 'saykit';
 import { Renderer } from '~/components/renderer.js';
-import { type PropsWithJSXSafeKeys, resolveJsxSafePropKeys } from '~/types.js';
+import { type PropsWithJSXSafeKeys, resolveValuePropKeys } from '~/types.js';
 
 declare function GET_SAY(): import('saykit').ReadonlySay;
 
@@ -30,15 +30,17 @@ export function Say(props: { id: string; whitespace?: boolean; [match: string]: 
     });
 
   const say = GET_SAY();
-  const { whitespace, ...rest } = props;
-  const descriptor = resolveJsxSafePropKeys(rest);
+  const { id, whitespace, ...rest } = props;
+  const values = resolveValuePropKeys(rest);
 
   return createElement(Renderer, {
-    html: say.call(descriptor),
+    // The id is kept out of `values` and merged in last, so a message free to
+    // name a tag `id` still cannot displace the message being looked up.
+    html: say.call({ ...values, id }),
     whitespace,
     components(tag?: string) {
-      if (tag && tag in descriptor && isValidElement(descriptor[tag])) {
-        const element = descriptor[tag]! as ReactElement;
+      if (tag && tag in values && isValidElement(values[tag])) {
+        const element = values[tag]! as ReactElement;
         return (props) => cloneElement(element, { ...(element.props as object), ...props });
       } else {
         return tag;

--- a/packages/integration-react/src/types.test.ts
+++ b/packages/integration-react/src/types.test.ts
@@ -1,20 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { resolveJsxSafePropKeys } from '~/types.js';
+import { resolveValuePropKeys } from '~/types.js';
 
-describe('resolveJsxSafePropKeys', () => {
-  it('strips the leading underscore from `_<digits>` keys', () => {
-    expect(resolveJsxSafePropKeys({ _0: 'a', _12: 'b' })).toEqual({ 0: 'a', 12: 'b' });
-  });
-
-  it('leaves other keys untouched', () => {
-    expect(resolveJsxSafePropKeys({ name: 'a', _tag: 'b', _1x: 'c' })).toEqual({
-      name: 'a',
-      _tag: 'b',
-      _1x: 'c',
+describe('resolveValuePropKeys', () => {
+  it('strips the leading underscore every value prop carries', () => {
+    expect(resolveValuePropKeys({ _0: 'a', _12: 'b', _name: 'c' })).toEqual({
+      0: 'a',
+      12: 'b',
+      name: 'c',
     });
   });
 
-  it('handles a mix of safe and unsafe keys', () => {
-    expect(resolveJsxSafePropKeys({ _0: 'zero', label: 'hi' })).toEqual({ 0: 'zero', label: 'hi' });
+  it('strips exactly one underscore, so a name that starts with one survives', () => {
+    expect(resolveValuePropKeys({ __link: 'a' })).toEqual({ _link: 'a' });
+  });
+
+  it('leaves keys without an underscore untouched', () => {
+    expect(resolveValuePropKeys({ name: 'a', label: 'b' })).toEqual({ name: 'a', label: 'b' });
   });
 });

--- a/packages/integration-react/src/types.ts
+++ b/packages/integration-react/src/types.ts
@@ -6,12 +6,19 @@ export type PropsWithJSXSafeKeys<T> = {
       : K]: T[K];
 };
 
-export function resolveJsxSafePropKeys<T extends Record<string, unknown>>(
+/**
+ * Map the props the transform compiled a message's values into back to the
+ * identifiers they carry. Every value is emitted with one underscore in front,
+ * which is what keeps a numbered identifier a valid prop name and what keeps
+ * any name a message chooses out of `Say`'s own namespace, so stripping exactly
+ * one is the whole inverse — `_0` is `0`, and `__link` is a tag named `_link`.
+ */
+export function resolveValuePropKeys<T extends Record<string, unknown>>(
   props: T,
 ): T & Record<string | number, unknown> {
   const result: Record<string, unknown> = {};
   for (const key in props) {
-    if (/^_\d+$/.test(key)) result[key.slice(1)] = props[key];
+    if (key.startsWith('_')) result[key.slice(1)] = props[key];
     else result[key] = props[key];
   }
   return result as T;

--- a/packages/integration-react/src/types.ts
+++ b/packages/integration-react/src/types.ts
@@ -12,14 +12,16 @@ export type PropsWithJSXSafeKeys<T> = {
  * which is what keeps a numbered identifier a valid prop name and what keeps
  * any name a message chooses out of `Say`'s own namespace, so stripping exactly
  * one is the whole inverse — `_0` is `0`, and `__link` is a tag named `_link`.
+ *
+ * The result is deliberately not typed as the props that went in: renaming the
+ * keys is the point, so claiming they survived would be a lie the only caller
+ * cannot use anyway, it looks tags up by a name that comes from a translation.
  */
-export function resolveValuePropKeys<T extends Record<string, unknown>>(
-  props: T,
-): T & Record<string | number, unknown> {
+export function resolveValuePropKeys(props: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const key in props) {
     if (key.startsWith('_')) result[key.slice(1)] = props[key];
     else result[key] = props[key];
   }
-  return result as T;
+  return result;
 }

--- a/packages/transform-jsx/src/generator.test.ts
+++ b/packages/transform-jsx/src/generator.test.ts
@@ -59,7 +59,7 @@ describe('generateSayJSXElement', () => {
     expect(expr.value).toBe(false);
   });
 
-  it('names numeric child keys with a leading underscore and passes others through', () => {
+  it('names every child key with a leading underscore', () => {
     const message = new CompositeMessage(
       { id: 'x' },
       [],
@@ -88,15 +88,15 @@ describe('generateSayJSXElement', () => {
       t.identifier('say'),
     );
 
-    // Numeric identifiers (`0`, `1`) get an underscore prefix; named ones do not.
+    // Values live behind an underscore, `Say`'s own props in front of it.
     expect(attrNames(generateSayJSXElement(message))).toEqual([
       'id',
-      'name',
+      '_name',
       '_0',
-      'inner',
+      '_inner',
       '_1',
-      'branch',
-      'deep',
+      '_branch',
+      '_deep',
     ]);
   });
 });

--- a/packages/transform-jsx/src/generator.ts
+++ b/packages/transform-jsx/src/generator.ts
@@ -21,7 +21,9 @@ export function generateSayJSXElement(message: CompositeMessage) {
             t.jsxExpressionContainer(t.booleanLiteral(message.whitespace)),
           ),
         ]),
-    ...children.map(([k, e]) =>
+    // An identifier can repeat — the same argument interpolated twice, or two
+    // identical elements sharing a tag — but it is one prop either way.
+    ...[...new Map(children).entries()].map(([k, e]) =>
       t.jsxAttribute(t.jsxIdentifier(Number.isNaN(+k) ? k : `_${k}`), t.jsxExpressionContainer(e)),
     ),
   ];

--- a/packages/transform-jsx/src/generator.ts
+++ b/packages/transform-jsx/src/generator.ts
@@ -23,8 +23,14 @@ export function generateSayJSXElement(message: CompositeMessage) {
         ]),
     // An identifier can repeat — the same argument interpolated twice, or two
     // identical elements sharing a tag — but it is one prop either way.
+    //
+    // Every value is emitted behind an underscore, which both makes numbered
+    // identifiers valid prop names and keeps them out of `Say`'s own namespace:
+    // no name a message can choose collides with `id` or `whitespace`, or with
+    // `key` and `ref` which React never passes on, and a prop added to `Say`
+    // later claims nothing. The runtime strips exactly one underscore back off.
     ...[...new Map(children).entries()].map(([k, e]) =>
-      t.jsxAttribute(t.jsxIdentifier(Number.isNaN(+k) ? k : `_${k}`), t.jsxExpressionContainer(e)),
+      t.jsxAttribute(t.jsxIdentifier(`_${k}`), t.jsxExpressionContainer(e)),
     ),
   ];
 

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -45,6 +45,28 @@ describe('createJsxTransformer.extract', () => {
     expect(message!.message).toBe('Hello, {name}!');
   });
 
+  it('names placeholders after their say-tag', () => {
+    const [message] = transformer.extract(
+      'const x = <Say>Click <a href="/x" say-tag="link">here</a> now</Say>;',
+      'file.tsx',
+    );
+    expect(message!.message).toBe('Click <link>here</link> now');
+  });
+
+  it('throws when two elements in a message share a tag', () => {
+    expect(() =>
+      transformer.extract(
+        'const x = <Say><b say-tag="bold">a</b> and <b say-tag="bold">c</b></Say>;',
+        'file.tsx',
+      ),
+    ).toThrow("Duplicate element tag 'bold'");
+  });
+
+  it('extracts childless elements as self-closing tags', () => {
+    const [message] = transformer.extract('const x = <Say>Open <ChevronDown /></Say>;', 'file.tsx');
+    expect(message!.message).toBe('Open <0/>');
+  });
+
   it('returns an empty array when there are no messages', () => {
     expect(transformer.extract('const x = <div>plain</div>;', 'file.tsx')).toEqual([]);
   });
@@ -63,6 +85,15 @@ describe('createJsxTransformer.transform', () => {
   it('rewrites a tagged template into a `.call`', () => {
     const output = transformer.transform('const x = say`Hello, ${name}!`;', 'file.tsx');
     expect(output).toContain('say.call(');
+  });
+
+  it('compiles a tagged element into a named prop without the say-tag attribute', () => {
+    const output = transformer.transform(
+      'const x = <Say>Click <a href="/x" say-tag="link">here</a></Say>;',
+      'file.tsx',
+    );
+    expect(output).toContain('link={<a href="/x">here</a>}');
+    expect(output).not.toContain('say-tag');
   });
 
   it('leaves code without messages untouched', () => {

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -96,7 +96,7 @@ describe('createJsxTransformer.transform', () => {
       'file.tsx',
     );
     expect(output).toContain('id="greeting"');
-    expect(output).toContain('name={name}');
+    expect(output).toContain('_name={name}');
   });
 
   it('rewrites a tagged template into a `.call`', () => {
@@ -109,7 +109,7 @@ describe('createJsxTransformer.transform', () => {
       'const x = <Say>Click <a href="/x" say-tag="link">here</a></Say>;',
       'file.tsx',
     );
-    expect(output).toContain('link={<a href="/x">here</a>}');
+    expect(output).toContain('_link={<a href="/x">here</a>}');
     expect(output).not.toContain('say-tag');
   });
 
@@ -118,7 +118,7 @@ describe('createJsxTransformer.transform', () => {
       'const x = <Say><b say-tag="bold">a</b> and <b say-tag="bold">c</b></Say>;',
       'file.tsx',
     );
-    expect(output.match(/bold=/g)).toHaveLength(1);
+    expect(output.match(/_bold=/g)).toHaveLength(1);
   });
 
   it('leaves code without messages untouched', () => {

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -56,10 +56,27 @@ describe('createJsxTransformer.extract', () => {
   it('throws when two elements in a message share a tag', () => {
     expect(() =>
       transformer.extract(
-        'const x = <Say><b say-tag="bold">a</b> and <b say-tag="bold">c</b></Say>;',
+        'const x = <Say><b say-tag="bold">a</b> and <i say-tag="bold">c</i></Say>;',
         'file.tsx',
       ),
     ).toThrow("Duplicate element tag 'bold'");
+  });
+
+  it('lets identical elements share a tag', () => {
+    const [message] = transformer.extract(
+      'const x = <Say><b say-tag="bold">a</b> and <b say-tag="bold">c</b></Say>;',
+      'file.tsx',
+    );
+    expect(message!.message).toBe('<bold>a</bold> and <bold>c</bold>');
+  });
+
+  it('throws when elements sharing a tag differ in their props', () => {
+    expect(() =>
+      transformer.extract(
+        'const x = <Say><a href="/x" say-tag="link">a</a> and <a href="/y" say-tag="link">c</a></Say>;',
+        'file.tsx',
+      ),
+    ).toThrow("Duplicate element tag 'link'");
   });
 
   it('extracts childless elements as self-closing tags', () => {
@@ -94,6 +111,14 @@ describe('createJsxTransformer.transform', () => {
     );
     expect(output).toContain('link={<a href="/x">here</a>}');
     expect(output).not.toContain('say-tag');
+  });
+
+  it('compiles identical elements sharing a tag into a single prop', () => {
+    const output = transformer.transform(
+      'const x = <Say><b say-tag="bold">a</b> and <b say-tag="bold">c</b></Say>;',
+      'file.tsx',
+    );
+    expect(output.match(/bold=/g)).toHaveLength(1);
   });
 
   it('leaves code without messages untouched', () => {

--- a/packages/transform-jsx/src/index.ts
+++ b/packages/transform-jsx/src/index.ts
@@ -6,7 +6,7 @@ import { assignSequenceIdentifiers, CompositeMessage } from '@saykit/config/feat
 import { generateSayCallExpression } from '@saykit/transform-js/generator';
 import { parseExpression } from '@saykit/transform-js/parser';
 import { generateSayJSXElement } from './generator.js';
-import { parseJSXElement } from './parser.js';
+import { isEquivalentElement, parseJSXElement } from './parser.js';
 
 const traverse = ((traverse_ as any).default || traverse_) as typeof traverse_;
 
@@ -48,7 +48,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 });
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
             messages.push(message);
             path.skip();
           }
@@ -58,7 +58,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseJSXElement(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 });
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
             messages.push(message);
             path.skip();
           }
@@ -84,7 +84,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 });
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
             const replacement = generateSayCallExpression(message);
             path.replaceWith(replacement);
             path.skip();
@@ -95,7 +95,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseJSXElement(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 });
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
             const replacement = generateSayJSXElement(message);
             path.replaceWith(replacement);
             path.skip();

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -292,4 +292,51 @@ describe('parseJSXElement', () => {
   it('returns ElementMessage (fallback=true) for unrecognised container element', () => {
     expect(parser.parseJSXElement(jsx`<span>text</span>`, true)).toBeInstanceOf(ElementMessage);
   });
+
+  describe('say-tag', () => {
+    it('names a container element after its tag', () => {
+      const result = parser.parseJSXElement(jsx`<a say-tag="link">here</a>`, true);
+      expect((result as ElementMessage).identifier).toBe('link');
+    });
+
+    it('names a self-closing element after its tag', () => {
+      const result = parser.parseJSXElement(jsx`<ChevronDown say-tag="icon" />`, true);
+      expect((result as ElementMessage).identifier).toBe('icon');
+    });
+
+    it('strips the attribute so it never reaches the rendered element', () => {
+      const element = jsx`<a href="/x" say-tag="link">here</a>`;
+      const result = parser.parseJSXElement(element, true) as ElementMessage;
+      const attributes = (result.expression as t.JSXElement).openingElement.attributes;
+      expect(attributes.map((a) => ((a as t.JSXAttribute).name as t.JSXIdentifier).name)).toEqual([
+        'href',
+      ]);
+    });
+
+    it('ignores a tag that is not a static string', () => {
+      const element = jsx`<a say-tag={name}>here</a>`;
+      const result = parser.parseJSXElement(element, true) as ElementMessage;
+      expect(result.identifier).toBe(AUTO_INCREMENT_IDENTIFIER);
+      // A dynamic value is left alone rather than silently dropped.
+      expect((result.expression as t.JSXElement).openingElement.attributes).toHaveLength(1);
+    });
+
+    it('falls back to auto-increment when there is no tag', () => {
+      const result = parser.parseJSXElement(jsx`<a href="/x">here</a>`, true);
+      expect((result as ElementMessage).identifier).toBe(AUTO_INCREMENT_IDENTIFIER);
+    });
+
+    it('throws for a tag that is not a valid identifier', () => {
+      expect(() => parser.parseJSXElement(jsx`<a say-tag="my link">here</a>`, true)).toThrow(
+        "Invalid 'say-tag' value 'my link'",
+      );
+    });
+
+    it('names elements nested inside a Say container', () => {
+      const result = parser.parseJSXContainerElement(
+        jsx`<Say>Click <a say-tag="link">here</a></Say>`,
+      );
+      expect((result!.children[1] as ElementMessage).identifier).toBe('link');
+    });
+  });
 });

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -313,6 +313,17 @@ describe('parseJSXElement', () => {
       ]);
     });
 
+    it('accepts a string literal in an expression container', () => {
+      const element = jsx`<a href="/x" say-tag={'link'}>here</a>`;
+      const result = parser.parseJSXElement(element, true) as ElementMessage;
+      expect(result.identifier).toBe('link');
+      // The attribute is consumed just as the bare-literal form is.
+      const attributes = (result.expression as t.JSXElement).openingElement.attributes;
+      expect(attributes.map((a) => ((a as t.JSXAttribute).name as t.JSXIdentifier).name)).toEqual([
+        'href',
+      ]);
+    });
+
     it('ignores a tag that is not a static string', () => {
       const element = jsx`<a say-tag={name}>here</a>`;
       const result = parser.parseJSXElement(element, true) as ElementMessage;

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -351,3 +351,31 @@ describe('parseJSXElement', () => {
     });
   });
 });
+
+describe('isEquivalentElement', () => {
+  // The children differ throughout: they come from the translation, so they
+  // never make two elements distinguishable.
+  it('treats elements with the same name and props as equivalent', () => {
+    expect(
+      parser.isEquivalentElement(jsx`<b className="x">a</b>`, jsx`<b className="x">c</b>`),
+    ).toBe(true);
+  });
+
+  it('treats differing props as distinguishable', () => {
+    expect(parser.isEquivalentElement(jsx`<a href="/x">a</a>`, jsx`<a href="/y">a</a>`)).toBe(
+      false,
+    );
+  });
+
+  it('treats differing element names as distinguishable', () => {
+    expect(parser.isEquivalentElement(jsx`<b>a</b>`, jsx`<i>a</i>`)).toBe(false);
+  });
+
+  it('treats a self-closing element as distinct from a container', () => {
+    expect(parser.isEquivalentElement(jsx`<Icon />`, jsx`<Icon>a</Icon>`)).toBe(false);
+  });
+
+  it('treats a non-element expression as distinguishable', () => {
+    expect(parser.isEquivalentElement(null, jsx`<b>a</b>`)).toBe(false);
+  });
+});

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -181,9 +181,9 @@ export function parseJSXElement(element: t.JSXElement, fallback?: boolean): Mess
 
 /**
  * Read the tag name off an embedded element and remove the attribute so it
- * never reaches the rendered element. Only static string literals name a tag;
- * anything else is left in place and the element falls back to an
- * auto-incremented identifier.
+ * never reaches the rendered element. Only static strings name a tag; anything
+ * else is left in place and the element falls back to an auto-incremented
+ * identifier.
  */
 function takeElementTag(element: t.JSXElement) {
   const attributes = element.openingElement.attributes;
@@ -193,9 +193,14 @@ function takeElementTag(element: t.JSXElement) {
   if (index === -1) return undefined;
 
   const attribute = attributes[index] as t.JSXAttribute;
-  if (!t.isStringLiteral(attribute.value)) return undefined;
+  // Both `say-tag="link"` and `say-tag={'link'}` are static; anything else is
+  // only known at runtime, too late to name a tag with.
+  const value = t.isJSXExpressionContainer(attribute.value)
+    ? attribute.value.expression
+    : attribute.value;
+  if (!t.isStringLiteral(value)) return undefined;
 
-  const tag = attribute.value.value;
+  const tag = value.value;
   if (!TAG_PATTERN.test(tag))
     throw new Error(
       `Invalid '${TAG_ATTRIBUTE}' value '${tag}', expected a letter or underscore followed by letters, digits, or underscores`,

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -9,6 +9,16 @@ import {
   type Message,
 } from '@saykit/config/features/messages';
 
+/**
+ * Attribute used to name the ICU tag an embedded element extracts as, e.g.
+ * `<a say-tag="link">` becomes `<link></link>` rather than `<0></0>`. It never
+ * reaches the real element.
+ */
+const TAG_ATTRIBUTE = 'say-tag';
+
+// A tag name is also used as a JSX prop name.
+const TAG_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export function parseJSXContainerElement(element: t.JSXElement): CompositeMessage | null {
   if (element.openingElement.selfClosing) return null;
   const processed = processJSXOpeningElement(element.openingElement);
@@ -154,8 +164,9 @@ export function parseJSXElement(element: t.JSXElement, fallback?: boolean): Mess
   if (message) return message;
   if (!fallback) return null;
 
-  if (element.openingElement.selfClosing)
-    return new ElementMessage(AUTO_INCREMENT_IDENTIFIER, [], element);
+  const identifier = takeElementTag(element) ?? AUTO_INCREMENT_IDENTIFIER;
+
+  if (element.openingElement.selfClosing) return new ElementMessage(identifier, [], element);
 
   const fake = t.jsxElement(
     t.jsxOpeningElement(t.jsxIdentifier('Say'), []),
@@ -165,7 +176,33 @@ export function parseJSXElement(element: t.JSXElement, fallback?: boolean): Mess
   // `parseJSXElement(fake, true)` always resolves (the synthesised element is a
   // `Say` container), so the wrapped message is never null.
   const wrapped = parseJSXElement(fake, true)!;
-  return new ElementMessage(AUTO_INCREMENT_IDENTIFIER, [wrapped], element);
+  return new ElementMessage(identifier, [wrapped], element);
+}
+
+/**
+ * Read the tag name off an embedded element and remove the attribute so it
+ * never reaches the rendered element. Only static string literals name a tag;
+ * anything else is left in place and the element falls back to an
+ * auto-incremented identifier.
+ */
+function takeElementTag(element: t.JSXElement) {
+  const attributes = element.openingElement.attributes;
+  const index = attributes.findIndex(
+    (a) => t.isJSXAttribute(a) && getAttributeNameAsString(a) === TAG_ATTRIBUTE,
+  );
+  if (index === -1) return undefined;
+
+  const attribute = attributes[index] as t.JSXAttribute;
+  if (!t.isStringLiteral(attribute.value)) return undefined;
+
+  const tag = attribute.value.value;
+  if (!TAG_PATTERN.test(tag))
+    throw new Error(
+      `Invalid '${TAG_ATTRIBUTE}' value '${tag}', expected a letter or underscore followed by letters, digits, or underscores`,
+    );
+
+  attributes.splice(index, 1);
+  return tag;
 }
 
 function getReferences(node: t.Node) {

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -210,6 +210,17 @@ function takeElementTag(element: t.JSXElement) {
   return tag;
 }
 
+/**
+ * Whether two elements sharing a tag are the same element, and so compile to
+ * one prop a translator can use interchangeably. `say-tag` has been stripped by
+ * the time this runs, so it compares the element name and the props left over,
+ * not the children: those come from the translation, not the source.
+ */
+export function isEquivalentElement(a: any, b: any) {
+  if (!t.isJSXElement(a) || !t.isJSXElement(b)) return false;
+  return t.isNodesEquivalent(a.openingElement, b.openingElement);
+}
+
 function getReferences(node: t.Node) {
   if (!node.loc?.filename) return [];
   return [`${node.loc.filename}:${node.loc.start.line}`];

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -234,7 +234,7 @@ JSX elements inside `<Say>` are preserved across translations as numbered tags:
 {items} items · total <0>{total}</0>
 ```
 
-Translators can move `<0>...</0>` around to fit the target language's grammar, and SayKit re-renders it with the original element at runtime.
+Translators can move `<0>...</0>` around to fit the target language's grammar, and SayKit re-renders it with the original element at runtime. A number tells a translator nothing about what the element does, so you can name one with `say-tag`, and an element with no children extracts as `<1/>` rather than a pair, see [naming tags](/integrations/react#naming-tags).
 
 `<Say>` also exposes sub-components for plurals, ordinals, and select:
 

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -38,9 +38,31 @@ function CheckoutSummary({ items, total }: { items: number; total: string }) {
 }
 ```
 
-Variables become named ICU placeholders (`{items}`, `{total}`). JSX elements inside `<Say>` become numbered tags (`<0>{total}</0>`) so translators can reorder them.
+Variables become named ICU placeholders (`{items}`, `{total}`). JSX elements inside `<Say>` become numbered tags (`<0>{total}</0>`) so translators can reorder them. Childless elements extract as self-closing tags (`<1/>`), so there is nowhere for a translator to insert content an icon never expected.
 
 `<Say>` works equally in server and client components, the package switches implementation based on the `react-server` condition.
+
+### Naming tags
+
+A numbered tag tells a translator nothing about what it does. Add `say-tag` to any element inside `<Say>` to name it:
+
+```tsx
+<Say>
+  Signed in as <strong say-tag="bold">{user}</strong>
+</Say>
+```
+
+The message extracts as `Signed in as <bold>{user}</bold>`. The attribute is compile-time only, it is stripped from the element and never reaches the DOM or a native view.
+
+Name the tag after what it does to the text, `bold`, `link`, `icon`, not after the content it happens to wrap. A translator sees only the tag name and the sentence around it, so `<bold>` tells them how the text will look, while `<user>` tells them nothing they can act on.
+
+Naming is opt-in and per element, so untagged elements keep their numbers alongside named ones. A tag must be a static string, and a valid identifier: a letter or underscore followed by letters, digits, or underscores.
+
+<Callout type="warn">
+  Every element in a message needs its own tag, two elements sharing one is a build error. Each
+  compiles to its own prop, and a translator reordering the sentence has to be able to tell them
+  apart. Give them distinct names, `link_docs` and `link_faq` rather than `link` twice.
+</Callout>
 
 ### Plurals, ordinals, select
 

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -58,9 +58,14 @@ Name the tag after what it does to the text, `bold`, `link`, `icon`, not after t
 
 Naming is opt-in and per element, so untagged elements keep their numbers alongside named ones. A tag must be a static string, and a valid identifier: a letter or underscore followed by letters, digits, or underscores.
 
+Two tagged elements in one message can share a name as long as they are identical, the same element
+with the same props, as `<b say-tag="bold">` twice is. They compile to one prop, and a translator
+still sees a single `<bold>` they can move around the sentence. Only the props are compared, not the
+content, since that comes from the translation.
+
 <Callout type="warn">
-  Two tagged elements in one message can't share a name, that's a build error. Each compiles to its
-  own prop, and a translator reordering the sentence has to be able to tell them apart. Give them
+  Elements that share a name but differ in any way are a build error. Each would compile to its own
+  prop, and a translator reordering the sentence has to be able to tell them apart. Give those
   distinct names, `link_docs` and `link_faq` rather than `link` twice. Elements you leave untagged
   are unaffected, they keep their numbers.
 </Callout>

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -59,9 +59,10 @@ Name the tag after what it does to the text, `bold`, `link`, `icon`, not after t
 Naming is opt-in and per element, so untagged elements keep their numbers alongside named ones. A tag must be a static string, and a valid identifier: a letter or underscore followed by letters, digits, or underscores.
 
 <Callout type="warn">
-  Every element in a message needs its own tag, two elements sharing one is a build error. Each
-  compiles to its own prop, and a translator reordering the sentence has to be able to tell them
-  apart. Give them distinct names, `link_docs` and `link_faq` rather than `link` twice.
+  Two tagged elements in one message can't share a name, that's a build error. Each compiles to its
+  own prop, and a translator reordering the sentence has to be able to tell them apart. Give them
+  distinct names, `link_docs` and `link_faq` rather than `link` twice. Elements you leave untagged
+  are unaffected, they keep their numbers.
 </Callout>
 
 ### Plurals, ordinals, select


### PR DESCRIPTION
Closes #61

Adds `say-tag`, an opt-in attribute for naming the ICU tag a JSX element extracts as, fixes childless elements extracting as paired tags, and moves compiled message values into their own prop namespace.

```tsx
<Say>
  Signed in as <strong say-tag="bold">{user}</strong>
</Say>
```

extracts as `Signed in as <bold>{user}</bold>` instead of `Signed in as <0>{user}</0>`.

## Behaviour

- The value must be a static string matching `/^[A-Za-z_][A-Za-z0-9_]*$/` — it becomes both an ICU tag and a JSX prop name. An invalid value throws; a non-literal value (`say-tag={x}`) is ignored and the element falls back to a number.
- The attribute is stripped at parse time, so it never reaches the DOM or a native view.
- Naming is opt-in per element. Untagged elements keep their numbers, and auto-numbering skips any number an explicit tag already claimed.
- Two elements in one message may share a tag when they are identical — same element name, same props, same self-closing-ness. They compile to one prop and a translator still sees a single `<bold>` to move around the sentence. Elements that share a tag but differ in any way are a build error: each would compile to its own prop, and a translator reordering the sentence has to be able to tell them apart. Only props are compared, never children, since those come from the translation. A tag colliding with an argument name (`say-tag="total"` alongside `{total}`) still throws.
- Childless elements now extract as `<0/>` rather than `<0></0>`, so there is nowhere for a translator to insert content an icon never expected. The renderer already parsed self-closing tags, so no runtime change was needed.

## Compiled values move behind an underscore

Every value the transform emits is now prefixed, and the runtime strips exactly one underscore back off:

```tsx
<Say whitespace={false}>Hi <b say-tag="id">{name}</b> <u/></Say>

// → <Say id="3WdqvG" whitespace={false} _id={<b>{name}</b>} _name={name} _0={<u />} />
```

`Say`'s own props sit in front of the underscore and message values behind it, so no tag or argument name is reserved and a prop added to `Say` later claims nothing. This replaces the earlier approach of rejecting `id`, `whitespace`, `key` and `ref` at parse time, which would have made every future prop a breaking change. Without it those four names silently broke: `say-tag="id"` emitted a duplicate `id` prop that displaced the message id, and `key`/`ref` never reach a component at all.

It generalises the `_0` escape that already existed for numeric identifiers rather than adding a second convention — stripping one underscore is the exact inverse, so `_0` is `0` and `__link` is a tag named `_link`. The message id is destructured out of the value props and merged back last, so an argument named `id` can no longer displace the message being looked up either.

Auto-deriving names from DOM tag names was left out deliberately, as was a `placeholderLabel()` macro for plain `` say`…` `` templates — both discussed in the issue thread, neither is in scope here. Plain templates keep the descriptor collision this fixes for JSX; that and their missing placeholder naming are tracked in #67.

## Breaking

- The self-closing fix changes `toICUString()`, so the generated hash id changes for any existing message containing a childless element, orphaning translations that have no explicit `id`. `say-tag` itself is opt-in and only churns messages you choose to name.
- The compiled prop shape changes, so `@saykit/transform-jsx` and `@saykit/react` have to be released together — an older runtime cannot read the prefixed props.

## Verification

- 337 tests pass; `pnpm -r check` and `pnpm lint` clean.
- End-to-end in `examples/react`: extraction produces `Assigned to <bold>{0}</bold>`, and the running app renders `Assigned to <strong>Amara</strong>` with no `say-tag` attributes left in the DOM.
- Confirmed by spike that hyphenated JSX attributes type-check on both intrinsic elements and custom components, so no typing work is needed for either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `say-tag` attributes to name JSX elements within `<Say>`, enabling clearer ICU placeholders and translator-controlled reordering.
  - JSX placeholders now compile with deterministic prop bindings, and childless elements are emitted as self-closing tags.

- **Bug Fixes**
  - Prevented identifier collisions between element tags and argument placeholders, including improved handling of duplicates via equivalence.
  - Improved conversion to avoid empty open/close tag output when elements have no renderable content.
  - Updated React runtime semantics for value prop keys (including underscore handling) so `id` and other props resolve correctly.

- **Documentation**
  - Expanded React integration guidance explaining `say-tag` rules, opt-in behaviour, stripping at compile time, and naming constraints for identical elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
