### PR TITLE
Name placeholders with a single-key object, and keep compiled values out of the descriptor's namespace

### DIFF
--- a/.changeset/brave-moons-repeat.md
+++ b/.changeset/brave-moons-repeat.md
@@ -1,0 +1,7 @@
+---
+'@saykit/transform-js': minor
+'@saykit/react': minor
+'saykit': minor
+---
+
+Compile message values behind an underscore so a value named `id` no longer displaces the message id

--- a/.changeset/olive-hounds-invent.md
+++ b/.changeset/olive-hounds-invent.md
@@ -1,0 +1,7 @@
+---
+'@saykit/transform-jsx': minor
+'@saykit/transform-js': minor
+'saykit': minor
+---
+
+Name a placeholder by interpolating a single-key object, `${{ cartTotal: getTotal() }}`

--- a/.changeset/olive-pans-repeat.md
+++ b/.changeset/olive-pans-repeat.md
@@ -1,0 +1,7 @@
+---
+'@saykit/transform-jsx': minor
+'@saykit/transform-js': minor
+'@saykit/config': minor
+---
+
+Reject two different values sharing a placeholder name, and allow a repeat when they are identical

--- a/packages/config/src/features/messages/identifier.test.ts
+++ b/packages/config/src/features/messages/identifier.test.ts
@@ -111,15 +111,44 @@ describe('assignSequenceIdentifiers', () => {
     );
   });
 
-  it('allows two arguments to share an identifier', () => {
+  it('allows two arguments to share a name when they are equivalent', () => {
     const message = new CompositeMessage(
       {},
       [],
       [],
-      [new ArgumentMessage('total', null), new ArgumentMessage('total', null)],
+      [new ArgumentMessage('total', 'sum'), new ArgumentMessage('total', 'sum')],
       null,
     );
-    expect(() => assignSequenceIdentifiers(message)).not.toThrow();
+    expect(() =>
+      assignSequenceIdentifiers(message, { current: 0 }, (a, b) => a === b),
+    ).not.toThrow();
+  });
+
+  it('throws when arguments sharing a name are not equivalent', () => {
+    const message = new CompositeMessage(
+      {},
+      [],
+      [],
+      [new ArgumentMessage('total', 'sum'), new ArgumentMessage('total', 'other')],
+      null,
+    );
+    expect(() => assignSequenceIdentifiers(message, { current: 0 }, (a, b) => a === b)).toThrow(
+      "Duplicate placeholder name 'total', give each value in a message its own name unless they are identical",
+    );
+  });
+
+  it('compares a choice against an argument of the same name', () => {
+    const choice = new ChoiceMessage('plural', 'count', [], 'n');
+    const message = new CompositeMessage(
+      {},
+      [],
+      [],
+      [choice, new ArgumentMessage('count', 'other')],
+      null,
+    );
+    expect(() => assignSequenceIdentifiers(message, { current: 0 }, (a, b) => a === b)).toThrow(
+      "Duplicate placeholder name 'count'",
+    );
   });
 
   it('throws when an element tag collides with an argument', () => {

--- a/packages/config/src/features/messages/identifier.ts
+++ b/packages/config/src/features/messages/identifier.ts
@@ -9,16 +9,16 @@ import {
 export const AUTO_INCREMENT_IDENTIFIER = Symbol('auto-increment');
 
 /**
- * Decides whether two elements sharing a tag are the same element, and so may
- * share it. Only the syntax that produced them can answer that, so the caller
- * supplies the comparison; by default no two elements are interchangeable.
+ * Decides whether two placeholders sharing a name are the same placeholder, and
+ * so may share it. Only the syntax that produced them can answer that, so the
+ * caller supplies the comparison; by default nothing is interchangeable.
  */
-export type ElementEquivalence = (a: any, b: any) => boolean;
+export type PlaceholderEquivalence = (a: any, b: any) => boolean;
 
 export function assignSequenceIdentifiers(
   message: Message,
   sequence = { current: 0 },
-  equivalent: ElementEquivalence = () => false,
+  equivalent: PlaceholderEquivalence = () => false,
 ) {
   const reserved = collectAssignedIdentifiers(message, equivalent);
 
@@ -51,30 +51,45 @@ export function assignSequenceIdentifiers(
  * Collect the identifiers already assigned before this pass runs, so generated
  * sequence numbers never shadow an explicit one (e.g. an element tagged `0`).
  *
- * Elements that differ need their own tag: they each compile to their own prop,
- * and a translator has to be able to tell them apart. Repeats are fine when
- * nothing distinguishes them — two identical elements are one prop, the same
- * way the same variable interpolated twice is one value — so arguments are
- * never checked and elements only when they are not equivalent.
+ * A name is claimed by what produced it, not by the name alone. Two that differ
+ * each compile to their own prop, and a translator moving them around a sentence
+ * has to be able to tell them apart, so they are a build error. Repeats are fine
+ * when nothing distinguishes them: the same variable interpolated twice is one
+ * value, and two identical elements are one tag.
  */
-function collectAssignedIdentifiers(message: Message, equivalent: ElementEquivalence) {
-  const tags = new Map<string, ElementMessage>();
-  const values = new Set<string>();
+function collectAssignedIdentifiers(message: Message, equivalent: PlaceholderEquivalence) {
+  const tags = new Map<string, unknown>();
+  const values = new Map<string, unknown>();
+
+  function claim(
+    claimed: Map<string, unknown>,
+    identifier: string,
+    expression: unknown,
+    conflict: string,
+  ) {
+    if (claimed.has(identifier) && !equivalent(claimed.get(identifier), expression))
+      throw new Error(conflict);
+    claimed.set(identifier, expression);
+  }
 
   function walk(message: Message) {
-    if (message instanceof ElementMessage && typeof message.identifier === 'string') {
-      const previous = tags.get(message.identifier);
-      if (previous && !equivalent(previous.expression, message.expression))
-        throw new Error(
-          `Duplicate element tag '${message.identifier}', give each element in a message its own tag unless they are identical`,
-        );
-      tags.set(message.identifier, message);
-    }
+    if (message instanceof ElementMessage && typeof message.identifier === 'string')
+      claim(
+        tags,
+        message.identifier,
+        message.expression,
+        `Duplicate element tag '${message.identifier}', give each element in a message its own tag unless they are identical`,
+      );
     if (
       (message instanceof ArgumentMessage || message instanceof ChoiceMessage) &&
       typeof message.identifier === 'string'
     )
-      values.add(message.identifier);
+      claim(
+        values,
+        message.identifier,
+        message.expression,
+        `Duplicate placeholder name '${message.identifier}', give each value in a message its own name unless they are identical`,
+      );
     if (message instanceof CompositeMessage || message instanceof ElementMessage)
       for (const child of message.children) walk(child);
     if (message instanceof ChoiceMessage) for (const branch of message.branches) walk(branch.value);
@@ -86,5 +101,5 @@ function collectAssignedIdentifiers(message: Message, equivalent: ElementEquival
     if (values.has(tag))
       throw new Error(`Element tag '${tag}' collides with an argument of the same name`);
 
-  return new Set([...tags.keys(), ...values]);
+  return new Set([...tags.keys(), ...values.keys()]);
 }

--- a/packages/integration-react/src/runtime/index.test.ts
+++ b/packages/integration-react/src/runtime/index.test.ts
@@ -73,10 +73,11 @@ describe('Say', () => {
       whitespace?: boolean;
       components: (tag?: string) => unknown;
     };
-    // The real id still reaches `say.call` and the tag named after it does not
-    // displace it, while a tag named `whitespace` is a value like any other and
-    // the flag itself still reaches the renderer.
-    expect(call).toHaveBeenCalledWith({ id: 'greet', whitespace: bold });
+    // The real id still reaches `say.call` and the value named after it does
+    // not displace it, since the two live in different namespaces until the
+    // runtime strips one underscore. The `whitespace` flag is destructured out
+    // for the renderer, while a value of that name rides along untouched.
+    expect(call).toHaveBeenCalledWith({ id: 'greet', _id: bold, _whitespace: bold });
     expect(props.whitespace).toBe(false);
     expect(typeof props.components('id')).toBe('function');
     expect(typeof props.components('whitespace')).toBe('function');

--- a/packages/integration-react/src/runtime/index.test.ts
+++ b/packages/integration-react/src/runtime/index.test.ts
@@ -40,9 +40,9 @@ describe('Say', () => {
     };
     expect(props.html).toBe('<name/> world');
     expect(props.whitespace).toBe(false);
-    // The descriptor passed to `say.call` has the value props unprefixed and
-    // the `whitespace` prop removed.
-    expect(call).toHaveBeenCalledWith(expect.objectContaining({ id: 'greet', name: bold }));
+    // The value props reach `say.call` still prefixed — the runtime does the
+    // single strip — with the id merged in and `whitespace` removed.
+    expect(call).toHaveBeenCalledWith({ id: 'greet', _name: bold });
 
     // A slot that maps to a valid element clones it; other slots pass the tag through.
     const resolved = props.components('name') as (p: object) => ReactElement;
@@ -77,6 +77,20 @@ describe('Say', () => {
     expect(props.whitespace).toBe(false);
     expect(typeof props.components('id')).toBe('function');
     expect(typeof props.components('whitespace')).toBe('function');
+  });
+
+  it('leaves a tag whose name starts with an underscore intact', () => {
+    const call = vi.fn(() => '<_link/>');
+    globalThis.GET_SAY = () => ({ call });
+
+    const link = createElement('a', null, 'here');
+    const element = (Say as (p: unknown) => ReactElement)({ id: 'greet', __link: link });
+
+    const props = element.props as { components: (tag?: string) => unknown };
+    // One strip in the runtime and one in the resolver, each on its own copy:
+    // `__link` reaches `say.call` untouched and resolves as `_link` for the tag.
+    expect(call).toHaveBeenCalledWith({ id: 'greet', __link: link });
+    expect(typeof props.components('_link')).toBe('function');
   });
 
   it('exposes Plural, Ordinal and Select macros that throw', () => {

--- a/packages/integration-react/src/runtime/index.ts
+++ b/packages/integration-react/src/runtime/index.ts
@@ -6,7 +6,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react';
-import type { Disallow, NumeralOptions, SelectOptions } from 'saykit';
+import type { Disallow, Named, NumeralOptions, SelectOptions } from 'saykit';
 import { Renderer } from '~/components/renderer.js';
 import { type PropsWithJSXSafeKeys, resolveValuePropKeys } from '~/types.js';
 
@@ -34,9 +34,11 @@ export function Say(props: { id: string; whitespace?: boolean; [match: string]: 
   const values = resolveValuePropKeys(rest);
 
   return createElement(Renderer, {
-    // The id is kept out of `values` and merged in last, so a message free to
-    // name a tag `id` still cannot displace the message being looked up.
-    html: say.call({ ...values, id }),
+    // The props go through still prefixed: `Say#call` does the single strip for
+    // every caller, so there is nowhere for it to happen twice. The id is
+    // merged in last, so a message free to name a value `id` still cannot
+    // displace the message being looked up.
+    html: say.call({ ...rest, id }),
     whitespace,
     components(tag?: string) {
       if (tag && tag in values && isValidElement(values[tag])) {
@@ -70,7 +72,9 @@ export namespace Say {
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
   export function Plural(
-    props: { _: number } & PropsWithJSXSafeKeys<Disallow<NumeralOptions, 'id' | 'context'>>,
+    props: { _: number | Named<number> } & PropsWithJSXSafeKeys<
+      Disallow<NumeralOptions, 'id' | 'context'>
+    >,
   ): ReactNode {
     void props;
     throw new Error("'Say.Plural' is a macro and must be used with the relevant saykit plugin");
@@ -96,7 +100,9 @@ export namespace Say {
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
   export function Ordinal(
-    props: { _: number } & PropsWithJSXSafeKeys<Disallow<NumeralOptions, 'id' | 'context'>>,
+    props: { _: number | Named<number> } & PropsWithJSXSafeKeys<
+      Disallow<NumeralOptions, 'id' | 'context'>
+    >,
   ): ReactNode {
     void props;
     throw new Error("'Say.Ordinal' is a macro and must be used with the relevant saykit plugin");
@@ -121,7 +127,9 @@ export namespace Say {
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
   export function Select(
-    props: { _: string } & PropsWithJSXSafeKeys<Disallow<SelectOptions, 'id' | 'context'>>,
+    props: { _: string | Named<string> } & PropsWithJSXSafeKeys<
+      Disallow<SelectOptions, 'id' | 'context'>
+    >,
   ): ReactNode {
     void props;
     throw new Error("'Say.Select' is a macro and must be used with the relevant saykit plugin");

--- a/packages/integration/src/runtime.test.ts
+++ b/packages/integration/src/runtime.test.ts
@@ -285,6 +285,24 @@ describe('Say.call', () => {
   it('strips exactly one underscore, so a name that starts with one survives', () => {
     expect(plain(make('en').call({ id: 'underscored', __total: '9' }))).toBe('Total 9');
   });
+
+  it('treats a value named `__proto__` as a value, not as a prototype', () => {
+    // Assigning the stripped key would write through to `Object.prototype`
+    // rather than naming a placeholder, so the values are built from own
+    // entries instead.
+    const descriptor = { id: 'named', _name: 'Ada' };
+    Object.defineProperty(descriptor, '___proto__', {
+      value: { polluted: true },
+      enumerable: true,
+    });
+    expect(plain(make('en').call(descriptor))).toBe('Hello, Ada');
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+  });
+
+  it('ignores keys a descriptor only inherits', () => {
+    const descriptor = Object.assign(Object.create({ _name: 'Ghost' }), { id: 'named' });
+    expect(plain(make('en').call(descriptor))).not.toContain('Ghost');
+  });
 });
 
 describe('Say inspect', () => {

--- a/packages/integration/src/runtime.test.ts
+++ b/packages/integration/src/runtime.test.ts
@@ -5,7 +5,13 @@ import { Say } from './runtime.js';
 type Locale = 'en' | 'fr' | 'de';
 
 const messages = {
-  en: { greeting: 'Hello', items: '{count, plural, one {# item} other {# items}}' },
+  en: {
+    greeting: 'Hello',
+    items: '{count, plural, one {# item} other {# items}}',
+    named: 'Hello, {name}',
+    identified: 'Order {id}',
+    underscored: 'Total {_total}',
+  },
   fr: { greeting: 'Bonjour', items: '{count, plural, one {# article} other {# articles}}' },
 } satisfies Partial<Record<Locale, Say.Messages>>;
 
@@ -19,6 +25,14 @@ const opts = (o: {
   messages?: Partial<Record<Locale, Say.Messages>>;
   loader?: Say.Loader<Locale>;
 }) => o as Say.Options<Locale, Say.Loader<Locale> | undefined>;
+
+/**
+ * Drop the bidi isolation marks the formatter wraps substituted values in, so
+ * an assertion can read as the sentence a user sees.
+ */
+function plain(formatted: string) {
+  return formatted.replaceAll(/[⁨⁩]/g, '');
+}
 
 function make(active?: Locale) {
   const say = new Say<Locale>(opts({ locales: ['en', 'fr', 'de'], messages }));
@@ -248,6 +262,28 @@ describe('Say.call', () => {
 
   it('throws when the message id is not found', () => {
     expect(() => make('en').call({ id: 'missing' })).toThrow('Message for missing is not a string');
+  });
+
+  it('strips the underscore the transform compiles values behind', () => {
+    expect(plain(make('en').call({ id: 'named', _name: 'Ada' }))).toBe('Hello, Ada');
+  });
+
+  it('formats keys written without one, so a hand-written call still works', () => {
+    expect(plain(make('en').call({ id: 'named', name: 'Ada' }))).toBe('Hello, Ada');
+  });
+
+  it('formats a value named after the descriptor id', () => {
+    // The lookup still uses the id; the value only fills `{id}` in the message.
+    expect(plain(make('en').call({ id: 'identified', _id: '42' }))).toBe('Order 42');
+  });
+
+  it('does not expose the message id as a value', () => {
+    // `{id}` is left unresolved rather than filled with the message's own id.
+    expect(plain(make('en').call({ id: 'identified' }))).not.toContain('identified');
+  });
+
+  it('strips exactly one underscore, so a name that starts with one survives', () => {
+    expect(plain(make('en').call({ id: 'underscored', __total: '9' }))).toBe('Total 9');
   });
 });
 

--- a/packages/integration/src/runtime.ts
+++ b/packages/integration/src/runtime.ts
@@ -8,15 +8,17 @@ import type { Disallow, Named, NumeralOptions, SelectOptions, Tuple } from './ty
  * one is the whole inverse — `_0` is `0`, and `__total` is a placeholder named
  * `_total`. Keys without one are passed through, so a hand-written
  * `call({ id, name })` still formats `{name}`.
+ *
+ * Built from the descriptor's own entries so a value named `__proto__` stays a
+ * placeholder rather than reaching through to the prototype.
  */
 function resolveDescriptorValues(descriptor: { id: string; [match: string | number]: unknown }) {
-  const values: Record<string, unknown> = {};
-  for (const key in descriptor) {
-    // The id names the message, it is not one of its values.
-    if (key === 'id') continue;
-    values[key.startsWith('_') ? key.slice(1) : key] = descriptor[key];
-  }
-  return values;
+  return Object.fromEntries(
+    Object.entries(descriptor)
+      // The id names the message, it is not one of its values.
+      .filter(([key]) => key !== 'id')
+      .map(([key, value]) => [key.startsWith('_') ? key.slice(1) : key, value]),
+  );
 }
 
 export namespace Say {

--- a/packages/integration/src/runtime.ts
+++ b/packages/integration/src/runtime.ts
@@ -1,5 +1,23 @@
 import { mf1ToMessage } from '@messageformat/icu-messageformat-1';
-import type { Disallow, NumeralOptions, SelectOptions, Tuple } from './types.js';
+import type { Disallow, Named, NumeralOptions, SelectOptions, Tuple } from './types.js';
+
+/**
+ * Map a descriptor's keys back to the placeholders the message names. The
+ * transform emits every value with one underscore in front, which keeps a
+ * message's values out of the descriptor's own namespace, so stripping exactly
+ * one is the whole inverse — `_0` is `0`, and `__total` is a placeholder named
+ * `_total`. Keys without one are passed through, so a hand-written
+ * `call({ id, name })` still formats `{name}`.
+ */
+function resolveDescriptorValues(descriptor: { id: string; [match: string | number]: unknown }) {
+  const values: Record<string, unknown> = {};
+  for (const key in descriptor) {
+    // The id names the message, it is not one of its values.
+    if (key === 'id') continue;
+    values[key.startsWith('_') ? key.slice(1) : key] = descriptor[key];
+  }
+  return values;
+}
 
 export namespace Say {
   export type Messages = { [key: string]: string };
@@ -20,9 +38,13 @@ export interface Say {
   /**
    * Define a message.
    *
+   * An interpolated variable is named after itself. Anything else is numbered,
+   * unless it is written as a single-key object, which names it.
+   *
    * @example
    * ```ts
    * say`Hello, ${name}!`
+   * say`Your total is ${{ cartTotal: getCartTotal() }}`
    * ```
    *
    * @remark This is a macro and must be used with the relevant saykit plugin
@@ -247,7 +269,7 @@ export class Say<
     const key = `${locale}:${descriptor.id}`;
     const format =
       this.#formats.get(key) ?? this.#formats.set(key, mf1ToMessage(locale, message)).get(key)!;
-    return String(format.format(descriptor));
+    return String(format.format(resolveDescriptorValues(descriptor)));
   }
 
   [Symbol.for('nodejs.util.inspect.custom')](
@@ -278,7 +300,7 @@ export class Say<
    * @returns The plural form of the number
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
-  plural(_: number, options: Disallow<NumeralOptions, 'id' | 'context'>): string {
+  plural(_: number | Named<number>, options: Disallow<NumeralOptions, 'id' | 'context'>): string {
     void _;
     void options;
     throw new Error("'Say#plural' is a macro and must be used with the relevant saykit plugin");
@@ -303,7 +325,7 @@ export class Say<
    * @returns The ordinal form of the number
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
-  ordinal(_: number, options: Disallow<NumeralOptions, 'id' | 'context'>): string {
+  ordinal(_: number | Named<number>, options: Disallow<NumeralOptions, 'id' | 'context'>): string {
     void _;
     void options;
     throw new Error("'Say#ordinal' is a macro and must be used with the relevant saykit plugin");
@@ -326,7 +348,7 @@ export class Say<
    * @returns The select form of the value
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
-  select(_: string, options: Disallow<SelectOptions, 'id' | 'context'>): string {
+  select(_: string | Named<string>, options: Disallow<SelectOptions, 'id' | 'context'>): string {
     void _;
     void options;
     throw new Error("'Say#select' is a macro and must be used with the relevant saykit plugin");

--- a/packages/integration/src/types.ts
+++ b/packages/integration/src/types.ts
@@ -4,6 +4,14 @@ export type Disallow<T, K extends PropertyKey> = T & Partial<Record<K, never>>;
 
 export type Awaitable<T> = T | PromiseLike<T>;
 
+/**
+ * A value wrapped in the name its ICU placeholder should take, written inline
+ * as a single-key object: `` say`Total: ${{ cartTotal: getTotal() }}` ``. The
+ * transform reads the key at build time and compiles only the value, so this
+ * is never a real object at runtime.
+ */
+export type Named<T> = { [name: string]: T };
+
 export interface NumeralOptions extends Omit<
   Partial<Record<Intl.LDMLPluralRule, string>>,
   'other'

--- a/packages/transform-js/src/generator.test.ts
+++ b/packages/transform-js/src/generator.test.ts
@@ -86,7 +86,46 @@ describe('generateSayCallExpression', () => {
 
     const result = generateSayCallExpression(message);
 
-    // id, then one key per non-literal child (elements/choices also emit their own children).
-    expect(callKeys(result)).toEqual(['id', 'name', '0', 'inner', 'count', 'choiceArg', 'deep']);
+    // id, then one key per non-literal child (elements/choices also emit their
+    // own children), every value behind an underscore.
+    expect(callKeys(result)).toEqual([
+      'id',
+      '_name',
+      '_0',
+      '_inner',
+      '_count',
+      '_choiceArg',
+      '_deep',
+    ]);
+  });
+
+  it('keeps a value named after the descriptor id out of its way', () => {
+    const message = new CompositeMessage(
+      { id: 'x' },
+      [],
+      [],
+      [new ArgumentMessage('id', t.identifier('id'))],
+      t.identifier('say'),
+    );
+
+    // Without the prefix both would be `id` and the later one would win,
+    // leaving the descriptor pointing at a value rather than at a message.
+    expect(callKeys(generateSayCallExpression(message))).toEqual(['id', '_id']);
+  });
+
+  it('emits one property for a repeated identifier', () => {
+    const message = new CompositeMessage(
+      { id: 'x' },
+      [],
+      [],
+      [
+        new ArgumentMessage('name', t.identifier('name')),
+        new LiteralMessage(' and '),
+        new ArgumentMessage('name', t.identifier('name')),
+      ],
+      t.identifier('say'),
+    );
+
+    expect(callKeys(generateSayCallExpression(message))).toEqual(['id', '_name']);
   });
 });

--- a/packages/transform-js/src/generator.ts
+++ b/packages/transform-js/src/generator.ts
@@ -13,7 +13,17 @@ export function generateSayCallExpression(message: CompositeMessage) {
 
   const properties = t.objectExpression([
     t.objectProperty(t.identifier('id'), t.stringLiteral(id)),
-    ...children.map(([ident, expr]) => t.objectProperty(t.identifier(ident), expr)),
+    // An identifier can repeat — the same argument interpolated twice — but it
+    // is one property either way.
+    //
+    // Every value is emitted behind an underscore, which both makes a numbered
+    // identifier a valid property name and keeps the message's values out of
+    // the descriptor's own namespace: an argument named `id` no longer
+    // displaces the message being looked up. The runtime strips exactly one
+    // underscore back off.
+    ...[...new Map(children).entries()].map(([ident, expr]) =>
+      t.objectProperty(t.identifier(`_${ident}`), expr),
+    ),
   ]);
 
   return t.callExpression(t.memberExpression(message.accessor, t.identifier('call')), [properties]);

--- a/packages/transform-js/src/index.test.ts
+++ b/packages/transform-js/src/index.test.ts
@@ -43,6 +43,25 @@ describe('createJsTransformer.extract', () => {
     expect(message!.message).toContain('plural');
   });
 
+  it('names a placeholder written as a single-key object', () => {
+    const [message] = transformer.extract(
+      'const t = say`Total: ${{ cartTotal: getTotal() }}`;',
+      'file.ts',
+    );
+    expect(message!.message).toBe('Total: {cartTotal}');
+  });
+
+  it('leaves unnamed placeholders numbered alongside named ones', () => {
+    const [message] = transformer.extract('const t = say`${{ total: a.b }} ${c.d}`;', 'file.ts');
+    expect(message!.message).toBe('{total} {0}');
+  });
+
+  it('throws for a name that is not a valid identifier', () => {
+    expect(() => transformer.extract("const t = say`${{ 'cart total': x }}`;", 'file.ts')).toThrow(
+      "Invalid placeholder name 'cart total'",
+    );
+  });
+
   it('returns an empty array when there are no messages', () => {
     expect(transformer.extract('const x = 1 + 2;', 'file.ts')).toEqual([]);
   });
@@ -52,8 +71,32 @@ describe('createJsTransformer.transform', () => {
   it('rewrites a tagged template into a `.call`', () => {
     const output = transformer.transform('const greeting = say`Hello, ${name}!`;', 'file.ts');
     expect(output).toContain('say.call(');
-    expect(output).toContain('name: name');
+    expect(output).toContain('_name: name');
     expect(output).not.toContain('say`');
+  });
+
+  it('keeps a value named `id` from displacing the message id', () => {
+    const output = transformer.transform('const g = say`Hi ${id}`;', 'file.ts');
+    // Both are properties of one object, so without the prefix the value would
+    // win and the descriptor would no longer name a message.
+    expect(output).toMatch(/id: "[^"]+"/);
+    expect(output).toContain('_id: id');
+  });
+
+  it('compiles a named placeholder without its wrapper', () => {
+    const output = transformer.transform(
+      'const t = say`Total: ${{ cartTotal: getTotal() }}`;',
+      'file.ts',
+    );
+    expect(output).toContain('_cartTotal: getTotal()');
+    // The single-key object that named it is gone, not nested inside the call.
+    expect(output).not.toContain('{ cartTotal:');
+  });
+
+  it('throws for a name that is not a valid identifier', () => {
+    expect(() =>
+      transformer.transform("const t = say`${{ 'cart total': x }}`;", 'file.ts'),
+    ).toThrow("Invalid placeholder name 'cart total'");
   });
 
   it('leaves code without messages untouched', () => {

--- a/packages/transform-js/src/index.test.ts
+++ b/packages/transform-js/src/index.test.ts
@@ -105,3 +105,45 @@ describe('createJsTransformer.transform', () => {
     expect(output).not.toContain('.call(');
   });
 });
+
+describe('duplicate placeholder names', () => {
+  it('allows the same value interpolated twice', () => {
+    const [message] = transformer.extract('const t = say`${name} and ${name}`;', 'file.ts');
+    expect(message!.message).toBe('{name} and {name}');
+    // One name is one value, so the repeat compiles to a single property.
+    const output = transformer.transform('const t = say`${name} and ${name}`;', 'file.ts');
+    expect(output.match(/_name:/g)).toHaveLength(1);
+  });
+
+  it('allows two named placeholders that name the same expression', () => {
+    const code = 'const t = say`${{ name: author.name }} and ${{ name: author.name }}`;';
+    expect(transformer.extract(code, 'file.ts')[0]!.message).toBe('{name} and {name}');
+    expect(transformer.transform(code, 'file.ts').match(/_name:/g)).toHaveLength(1);
+  });
+
+  it('rejects one name given to two different expressions', () => {
+    expect(() =>
+      transformer.extract(
+        'const t = say`${{ n: items.length }} ${{ n: users.length }}`;',
+        'file.ts',
+      ),
+    ).toThrow(
+      "Duplicate placeholder name 'n', give each value in a message its own name unless they are identical",
+    );
+  });
+
+  it('rejects a name that collides with a variable interpolated directly', () => {
+    expect(() =>
+      transformer.transform('const t = say`${name} ${{ name: author.name }}`;', 'file.ts'),
+    ).toThrow("Duplicate placeholder name 'name'");
+  });
+
+  it('compares a choice selector against the values around it', () => {
+    expect(() =>
+      transformer.extract(
+        "const t = say`${count} ${say.plural({ count: items.length }, { other: '#' })}`;",
+        'file.ts',
+      ),
+    ).toThrow("Duplicate placeholder name 'count'");
+  });
+});

--- a/packages/transform-js/src/index.ts
+++ b/packages/transform-js/src/index.ts
@@ -4,7 +4,7 @@ import traverse_ from '@babel/traverse';
 import type { Transformer } from '@saykit/config';
 import { assignSequenceIdentifiers, CompositeMessage } from '@saykit/config/features/messages';
 import { generateSayCallExpression } from './generator.js';
-import { parseExpression } from './parser.js';
+import { isEquivalentPlaceholder, parseExpression } from './parser.js';
 
 const traverse = ((traverse_ as any).default || traverse_) as typeof traverse_;
 
@@ -46,7 +46,7 @@ function createJsTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 });
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
             messages.push(message);
             path.skip();
           }
@@ -72,7 +72,7 @@ function createJsTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 });
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
             const replacement = generateSayCallExpression(message);
             path.replaceWith(replacement);
             path.skip();

--- a/packages/transform-js/src/parser.test.ts
+++ b/packages/transform-js/src/parser.test.ts
@@ -339,3 +339,69 @@ describe('parseExpression', () => {
     expect((result!.children[1] as ArgumentMessage).identifier).toBe(AUTO_INCREMENT_IDENTIFIER);
   });
 });
+
+describe('unwrapPlaceholder', () => {
+  it('names a value written as a single-key object', () => {
+    const object = expr<t.ObjectExpression>('({ cartTotal: getTotal() })');
+    const property = object.properties[0] as t.ObjectProperty;
+    expect(parser.unwrapPlaceholder(object)).toEqual(['cartTotal', property.value]);
+  });
+
+  it('names a template interpolation the value would otherwise number', () => {
+    const result = parser.parseExpression(expr('say`Total: ${{ cartTotal: getTotal() }}`'));
+    const argument = result!.children[1] as ArgumentMessage;
+    expect(argument.identifier).toBe('cartTotal');
+    // The wrapper is gone, only the value it held is compiled.
+    expect(t.isCallExpression(argument.expression)).toBe(true);
+    expect(((argument.expression as t.CallExpression).callee as t.Identifier).name).toBe(
+      'getTotal',
+    );
+  });
+
+  it('accepts a quoted key and a shorthand property', () => {
+    expect(parser.unwrapPlaceholder(expr("({ 'cartTotal': x })"))[0]).toBe('cartTotal');
+    expect(parser.unwrapPlaceholder(expr('({ total })'))[0]).toBe('total');
+  });
+
+  it.each([
+    ['a name that is not a valid identifier', "({ 'cart-total': x })"],
+    ['a numeric name', '({ 0: x })'],
+  ])('throws for %s', (_, code) => {
+    expect(() => parser.unwrapPlaceholder(expr(code))).toThrow('Invalid placeholder name');
+  });
+
+  it.each([
+    ['more than one key', '({ a: 1, b: 2 })'],
+    ['no keys', '({})'],
+    ['a computed key', '({ [key]: x })'],
+    ['a spread', '({ ...rest })'],
+    ['a method', '({ a() {} })'],
+  ])('leaves an object with %s untouched', (_, code) => {
+    // Only the one shape that could not already mean something is claimed.
+    const object = expr<t.ObjectExpression>(code);
+    expect(parser.unwrapPlaceholder(object)).toEqual([AUTO_INCREMENT_IDENTIFIER, object]);
+  });
+
+  it('passes a plain expression through as it always was', () => {
+    const identifier = expr('name');
+    expect(parser.unwrapPlaceholder(identifier)).toEqual(['name', identifier]);
+    const member = expr('obj.prop');
+    expect(parser.unwrapPlaceholder(member)).toEqual([AUTO_INCREMENT_IDENTIFIER, member]);
+  });
+
+  it('names a choice selector', () => {
+    const result = parser.parseExpression(
+      expr("say.plural({ n: items.length }, { one: '# item', other: '# items' })"),
+    );
+    const choice = result!.children[0] as ChoiceMessage;
+    expect(choice.identifier).toBe('n');
+    expect(t.isMemberExpression(choice.expression)).toBe(true);
+  });
+
+  it('keeps a named `say` macro a message of its own', () => {
+    const result = parser.parseExpression(expr('say`Hi ${{ nested: say`there` }}`'));
+    // The name is dropped rather than applied to a nested message, but no macro
+    // survives into the output.
+    expect(result!.children[1]).toBeInstanceOf(CompositeMessage);
+  });
+});

--- a/packages/transform-js/src/parser.test.ts
+++ b/packages/transform-js/src/parser.test.ts
@@ -405,3 +405,36 @@ describe('unwrapPlaceholder', () => {
     expect(result!.children[1]).toBeInstanceOf(CompositeMessage);
   });
 });
+
+describe('isEquivalentPlaceholder, on values', () => {
+  it('treats the same variable interpolated twice as one value', () => {
+    expect(parser.isEquivalentPlaceholder(expr('name'), expr('name'))).toBe(true);
+  });
+
+  it('treats the same member chain written twice as one value', () => {
+    expect(parser.isEquivalentPlaceholder(expr('author.name'), expr('author.name'))).toBe(true);
+  });
+
+  it('treats a variable and a member chain as distinguishable', () => {
+    // The shape `${name}` beside `${{ name: author.name }}` reduces to.
+    expect(parser.isEquivalentPlaceholder(expr('name'), expr('author.name'))).toBe(false);
+  });
+
+  it('treats different member chains as distinguishable', () => {
+    expect(parser.isEquivalentPlaceholder(expr('items.length'), expr('users.length'))).toBe(false);
+  });
+
+  it('ignores where in the source each one was written', () => {
+    // The same expression written at two points in a message parses to nodes
+    // that differ in position, which must not make them two placeholders.
+    const a = expr('cart.total');
+    const b = expr('  cart.total');
+    expect(a.start).not.toBe(b.start);
+    expect(parser.isEquivalentPlaceholder(a, b)).toBe(true);
+  });
+
+  it('treats anything that is not a node as distinguishable', () => {
+    expect(parser.isEquivalentPlaceholder(null, null)).toBe(false);
+    expect(parser.isEquivalentPlaceholder(expr('name'), undefined)).toBe(false);
+  });
+});

--- a/packages/transform-js/src/parser.ts
+++ b/packages/transform-js/src/parser.ts
@@ -8,6 +8,9 @@ import {
   type Message,
 } from '@saykit/config/features/messages';
 
+// A placeholder name is also used as a property name in the compiled call.
+const PLACEHOLDER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 export function parseTaggedTemplateExpression(
   tagged: t.TaggedTemplateExpression,
 ): CompositeMessage | null {
@@ -63,8 +66,7 @@ export function parseCallExpression(call: t.CallExpression): CompositeMessage | 
       return c;
     }, []);
 
-    const value = call.arguments[0];
-    const identifier = getExpressionAsKey(value);
+    const [identifier, value] = unwrapPlaceholder(call.arguments[0]);
     const choice = new ChoiceMessage(kind, identifier, branches, value);
 
     const descriptorId = descriptor
@@ -130,6 +132,42 @@ function getExpressionAsKey(node: t.Node) {
   return AUTO_INCREMENT_IDENTIFIER;
 }
 
+/**
+ * Read the name off a value written as a single-key object and hand back the
+ * value alone, so the wrapper never reaches the output: `${{ total: sum() }}`
+ * is `{total}` rather than `{0}`.
+ *
+ * An inline one-key object is the only shape this claims, and it is a shape
+ * that could not mean anything else — interpolating an object stringifies it
+ * to `[object Object]`, and rendering one in JSX throws. Anything else is
+ * returned untouched and named the way it always was.
+ */
+export function unwrapPlaceholder(
+  expression: t.Expression,
+): [string | typeof AUTO_INCREMENT_IDENTIFIER, t.Expression] {
+  if (!t.isObjectExpression(expression) || expression.properties.length !== 1)
+    return [getExpressionAsKey(expression), expression];
+
+  const [property] = expression.properties;
+  // A computed key is only known at runtime, too late to name a placeholder
+  // with, and a method has no value to interpolate.
+  if (!t.isObjectProperty(property) || property.computed || !t.isExpression(property.value))
+    return [getExpressionAsKey(expression), expression];
+
+  const name = getPropertyNameAsString(property.key);
+  // A key that is not computed is always an identifier or a literal, so it
+  // always reads back as a string.
+  /* v8 ignore next */
+  if (typeof name !== 'string') return [getExpressionAsKey(expression), expression];
+
+  if (!PLACEHOLDER_PATTERN.test(name))
+    throw new Error(
+      `Invalid placeholder name '${name}', expected a letter or underscore followed by letters, digits, or underscores`,
+    );
+
+  return [name, property.value];
+}
+
 export function parseExpression(
   expression: t.Expression,
   fallback?: false,
@@ -152,8 +190,14 @@ export function parseExpression(expression: t.Expression, fallback?: boolean) {
   if (message) {
     return message;
   } else if (fallback) {
-    const key = getExpressionAsKey(expression);
-    return new ArgumentMessage(key, expression);
+    const [key, value] = unwrapPlaceholder(expression);
+    // A named `say` macro is still a message of its own, and emitting it as a
+    // value would ship a macro the transform never replaced.
+    if (value !== expression) {
+      const nested = parseExpression(value);
+      if (nested) return nested;
+    }
+    return new ArgumentMessage(key, value);
   } else {
     return null;
   }

--- a/packages/transform-js/src/parser.ts
+++ b/packages/transform-js/src/parser.ts
@@ -168,6 +168,25 @@ export function unwrapPlaceholder(
   return [name, property.value];
 }
 
+/**
+ * Whether two placeholders sharing a name are the same placeholder, and so
+ * compile to one prop a translator can move around the sentence freely.
+ *
+ * A value is compared whole: the same variable interpolated twice is one value,
+ * while `${name}` beside `${{ name: author.name }}` is two things claiming one
+ * name. An element is compared on its opening element alone — `say-tag` has
+ * been stripped by the time this runs, and its children come from the
+ * translation rather than the source.
+ */
+export function isEquivalentPlaceholder(a: any, b: any) {
+  if (t.isJSXElement(a) || t.isJSXElement(b)) {
+    if (!t.isJSXElement(a) || !t.isJSXElement(b)) return false;
+    return t.isNodesEquivalent(a.openingElement, b.openingElement);
+  }
+  if (!t.isNode(a) || !t.isNode(b)) return false;
+  return t.isNodesEquivalent(a, b);
+}
+
 export function parseExpression(
   expression: t.Expression,
   fallback?: false,

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -158,3 +158,26 @@ describe('createJsxTransformer.transform', () => {
     expect(output).toContain('<div>plain</div>');
   });
 });
+
+describe('duplicate placeholder names', () => {
+  it('allows the same value interpolated twice', () => {
+    const [message] = transformer.extract('<Say>{name} and {name}</Say>', 'file.tsx');
+    expect(message!.message).toBe('{name} and {name}');
+    const output = transformer.transform('<Say>{name} and {name}</Say>', 'file.tsx');
+    expect(output.match(/_name=/g)).toHaveLength(1);
+  });
+
+  it('rejects one name given to two different expressions', () => {
+    expect(() =>
+      transformer.extract('<Say>{{ who: a.name }} and {{ who: b.name }}</Say>', 'file.tsx'),
+    ).toThrow("Duplicate placeholder name 'who'");
+  });
+
+  it('rejects a value name that collides with an element tag', () => {
+    // Tags and values share one namespace in the compiled props, so this stays
+    // the harder error it always was.
+    expect(() =>
+      transformer.extract('<Say>{link} <a say-tag="link">here</a></Say>', 'file.tsx'),
+    ).toThrow("Element tag 'link' collides with an argument of the same name");
+  });
+});

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -79,6 +79,28 @@ describe('createJsxTransformer.extract', () => {
     ).toThrow("Duplicate element tag 'link'");
   });
 
+  it('names a JSX interpolation written as a single-key object', () => {
+    const [message] = transformer.extract(
+      'const x = <Say>Hi {{ who: user.name }}</Say>;',
+      'file.tsx',
+    );
+    expect(message!.message).toBe('Hi {who}');
+  });
+
+  it('names a choice initialiser written as a single-key object', () => {
+    const [message] = transformer.extract(
+      'const x = <Say.Plural _={{ items: cart.length }} one="# item" other="# items" />;',
+      'file.tsx',
+    );
+    expect(message!.message).toContain('{items, plural,');
+  });
+
+  it('throws for a placeholder name that is not a valid identifier', () => {
+    expect(() =>
+      transformer.extract("const x = <Say>Hi {{ 'who is': user.name }}</Say>;", 'file.tsx'),
+    ).toThrow("Invalid placeholder name 'who is'");
+  });
+
   it('extracts childless elements as self-closing tags', () => {
     const [message] = transformer.extract('const x = <Say>Open <ChevronDown /></Say>;', 'file.tsx');
     expect(message!.message).toBe('Open <0/>');
@@ -119,6 +141,16 @@ describe('createJsxTransformer.transform', () => {
       'file.tsx',
     );
     expect(output.match(/_bold=/g)).toHaveLength(1);
+  });
+
+  it('compiles a named interpolation into a prop without its wrapper', () => {
+    const output = transformer.transform(
+      'const x = <Say>Hi {{ who: user.name }}</Say>;',
+      'file.tsx',
+    );
+    expect(output).toContain('_who={user.name}');
+    // The single-key object that named it is gone, not passed as a prop value.
+    expect(output).not.toContain('{ who:');
   });
 
   it('leaves code without messages untouched', () => {

--- a/packages/transform-jsx/src/index.ts
+++ b/packages/transform-jsx/src/index.ts
@@ -4,9 +4,9 @@ import traverse_ from '@babel/traverse';
 import type { Transformer } from '@saykit/config';
 import { assignSequenceIdentifiers, CompositeMessage } from '@saykit/config/features/messages';
 import { generateSayCallExpression } from '@saykit/transform-js/generator';
-import { parseExpression } from '@saykit/transform-js/parser';
+import { isEquivalentPlaceholder, parseExpression } from '@saykit/transform-js/parser';
 import { generateSayJSXElement } from './generator.js';
-import { isEquivalentElement, parseJSXElement } from './parser.js';
+import { parseJSXElement } from './parser.js';
 
 const traverse = ((traverse_ as any).default || traverse_) as typeof traverse_;
 
@@ -48,7 +48,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
             messages.push(message);
             path.skip();
           }
@@ -58,7 +58,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseJSXElement(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
             messages.push(message);
             path.skip();
           }
@@ -84,7 +84,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
             const replacement = generateSayCallExpression(message);
             path.replaceWith(replacement);
             path.skip();
@@ -95,7 +95,7 @@ function createJsxTransformer(): Transformer {
           path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseJSXElement(path.node);
           if (message) {
-            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentElement);
+            assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
             const replacement = generateSayJSXElement(message);
             path.replaceWith(replacement);
             path.skip();

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -8,6 +8,7 @@ import {
   ElementMessage,
   LiteralMessage,
 } from '@saykit/config/features/messages';
+import { isEquivalentPlaceholder } from '@saykit/transform-js/parser';
 import { describe, expect, it } from 'vitest';
 import * as parser from './parser.js';
 
@@ -352,30 +353,36 @@ describe('parseJSXElement', () => {
   });
 });
 
-describe('isEquivalentElement', () => {
+// The comparison itself lives in `@saykit/transform-js` so both transformers
+// share one rule; the element half of it is exercised here, where the JSX is.
+describe('isEquivalentPlaceholder, on elements', () => {
   // The children differ throughout: they come from the translation, so they
   // never make two elements distinguishable.
   it('treats elements with the same name and props as equivalent', () => {
-    expect(
-      parser.isEquivalentElement(jsx`<b className="x">a</b>`, jsx`<b className="x">c</b>`),
-    ).toBe(true);
-  });
-
-  it('treats differing props as distinguishable', () => {
-    expect(parser.isEquivalentElement(jsx`<a href="/x">a</a>`, jsx`<a href="/y">a</a>`)).toBe(
-      false,
+    expect(isEquivalentPlaceholder(jsx`<b className="x">a</b>`, jsx`<b className="x">c</b>`)).toBe(
+      true,
     );
   });
 
+  it('treats differing props as distinguishable', () => {
+    expect(isEquivalentPlaceholder(jsx`<a href="/x">a</a>`, jsx`<a href="/y">a</a>`)).toBe(false);
+  });
+
   it('treats differing element names as distinguishable', () => {
-    expect(parser.isEquivalentElement(jsx`<b>a</b>`, jsx`<i>a</i>`)).toBe(false);
+    expect(isEquivalentPlaceholder(jsx`<b>a</b>`, jsx`<i>a</i>`)).toBe(false);
   });
 
   it('treats a self-closing element as distinct from a container', () => {
-    expect(parser.isEquivalentElement(jsx`<Icon />`, jsx`<Icon>a</Icon>`)).toBe(false);
+    expect(isEquivalentPlaceholder(jsx`<Icon />`, jsx`<Icon>a</Icon>`)).toBe(false);
   });
 
   it('treats a non-element expression as distinguishable', () => {
-    expect(parser.isEquivalentElement(null, jsx`<b>a</b>`)).toBe(false);
+    expect(isEquivalentPlaceholder(null, jsx`<b>a</b>`)).toBe(false);
+  });
+
+  it('never matches an element against a value, whichever side it is on', () => {
+    const value = parseExpression('user.name') as unknown as t.Expression;
+    expect(isEquivalentPlaceholder(jsx`<b>a</b>`, value)).toBe(false);
+    expect(isEquivalentPlaceholder(value, jsx`<b>a</b>`)).toBe(false);
   });
 });

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -8,6 +8,7 @@ import {
   LiteralMessage,
   type Message,
 } from '@saykit/config/features/messages';
+import { unwrapPlaceholder } from '@saykit/transform-js/parser';
 
 /**
  * Attribute used to name the ICU tag an embedded element extracts as, e.g.
@@ -38,8 +39,10 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
     } else if (t.isJSXFragment(c)) {
       p.push(new ElementMessage(AUTO_INCREMENT_IDENTIFIER, [], c));
     } else if (t.isJSXExpressionContainer(c)) {
-      if (t.isExpression(c.expression))
-        p.push(new ArgumentMessage(getExpressionAsIdentifier(c.expression), c.expression));
+      if (t.isExpression(c.expression)) {
+        const [identifier, value] = unwrapPlaceholder(c.expression);
+        p.push(new ArgumentMessage(identifier, value));
+      }
     }
 
     return p;
@@ -98,13 +101,8 @@ export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeM
             value: new ElementMessage(AUTO_INCREMENT_IDENTIFIER, [], a.value.expression),
           });
         } else if (t.isExpression(a.value.expression)) {
-          b.push({
-            identifier,
-            value: new ArgumentMessage(
-              getExpressionAsIdentifier(a.value.expression),
-              a.value.expression,
-            ),
-          });
+          const [name, value] = unwrapPlaceholder(a.value.expression);
+          b.push({ identifier, value: new ArgumentMessage(name, value) });
         }
       }
 
@@ -113,8 +111,8 @@ export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeM
 
     const initialiser = findAttributeValueIfExpressionOrStringLiteral(element.attributes, '_');
     if (!initialiser) return null;
-    const identifier = getExpressionAsIdentifier(initialiser);
-    const choice = new ChoiceMessage(kind, identifier, branches, initialiser);
+    const [identifier, selector] = unwrapPlaceholder(initialiser);
+    const choice = new ChoiceMessage(kind, identifier, branches, selector);
 
     const descriptorId = findAttributeValueIfStringLiteralAsString(element.attributes, 'id');
     const descriptorContext = findAttributeValueIfStringLiteralAsString(
@@ -275,13 +273,4 @@ function findAttributeValueAsBoolean(
       return attribute.value.expression.value;
   }
   return undefined;
-}
-
-function getExpressionAsIdentifier(node: t.Node) {
-  if (t.isIdentifier(node)) return node.name;
-  // Initialiser and argument nodes are always plain expressions here, never a
-  // bare JSX identifier, so this branch is unreachable in practice.
-  /* v8 ignore next */
-  if (t.isJSXIdentifier(node)) return node.name;
-  return AUTO_INCREMENT_IDENTIFIER;
 }

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -208,17 +208,6 @@ function takeElementTag(element: t.JSXElement) {
   return tag;
 }
 
-/**
- * Whether two elements sharing a tag are the same element, and so compile to
- * one prop a translator can use interchangeably. `say-tag` has been stripped by
- * the time this runs, so it compares the element name and the props left over,
- * not the children: those come from the translation, not the source.
- */
-export function isEquivalentElement(a: any, b: any) {
-  if (!t.isJSXElement(a) || !t.isJSXElement(b)) return false;
-  return t.isNodesEquivalent(a.openingElement, b.openingElement);
-}
-
 function getReferences(node: t.Node) {
   if (!node.loc?.filename) return [];
   return [`${node.loc.filename}:${node.loc.start.line}`];

--- a/website/content/core-concepts/architecture.mdx
+++ b/website/content/core-concepts/architecture.mdx
@@ -99,7 +99,7 @@ const say = new Say({
 
 say.activate('en');
 
-say.call({ id: 'abc123', name: 'Ada' });
+say.call({ id: 'abc123', _name: 'Ada' });
 // → "Hello, Ada!"
 ```
 
@@ -109,7 +109,7 @@ You almost never write `say.call(...)` by hand, the build transform generates it
 say`Hello, ${name}!`;
 ```
 
-The transformer takes that tagged template, extracts the literal text plus the placeholder, computes a stable hash id, and rewrites the source to call `say.call({ id: '...', name })`.
+The transformer takes that tagged template, extracts the literal text plus the placeholder, computes a stable hash id, and rewrites the source to call `say.call({ id: '...', _name: name })`. Values are emitted behind an underscore so they keep their own namespace, the runtime strips it back off.
 
 See [runtime](/core-concepts/runtime) for the full API and [messages](/core-concepts/messages) for what's authorable.
 

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -82,11 +82,33 @@ say.plural({ items: cart.length }, { one: '# item', other: '# items' });
 ```
 
 <Callout type="info">
-  Only an object written inline with exactly one key is read as a name. A variable holding an object
-  (`` say`${data}` ``) is a value like any other, and so is an object with two keys, a spread, or a
-  computed key. Interpolating an object was never meaningful, it stringifies to `[object Object]`,
-  so nothing that used to work changes meaning.
+  Only an object written inline with exactly one key is read as a name, and that is the one shape
+  whose meaning changes: it used to format as its own value, `[object Object]`, and now names the
+  value inside it. A variable holding an object (`` say`${data}` ``) is untouched, and so is an
+  object with two keys, a spread, or a computed key, they all stay values like any other.
 </Callout>
+
+### Reusing a name
+
+A name belongs to a value, not to a position, so interpolating the same value twice is one
+placeholder, and a translator can move it around the sentence or drop it entirely:
+
+```ts
+say`${name} invited ${name}'s team`; // → "{name} invited {name}'s team"
+say`${{ total: cart.total }} of ${{ total: cart.total }}`; // → "{total} of {total}"
+```
+
+<Callout type="warn">
+  Two different values under one name are a build error, whether they got there by naming
+  (`` say`${{ n: items.length }} ${{ n: users.length }}` ``) or by one name colliding with a variable
+  (`` say`${name} ${{ name: author.name }}` ``). Only one of them could survive into the compiled
+  call, and a translator has no way to tell them apart. Give them their own names, `itemCount` and
+  `userCount` rather than `n` twice.
+</Callout>
+
+Note that a repeat is evaluated once. Two identical placeholders compile to a single value, so if the
+expression does work, or has a side effect, it happens once no matter how many times the message
+mentions it.
 
 ## Plurals
 

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -38,7 +38,9 @@ The transform does five things:
 2. Converts them to ICU MessageFormat.
 3. Generates a stable 6-character hash id from the message text + context.
 4. Records the file and line as a translator reference.
-5. Replaces the source expression with a `say.call({ id, ...values })` call.
+5. Replaces the source expression with a `say.call({ id, ...values })` call, each value behind an
+   underscore (`_name`) so a value can be named anything without colliding with the descriptor's own
+   keys. The runtime strips it back off.
 
 <Callout type="info">
   SayKit looks for the identifier `say` when transforming messages. Anything named `say` works ,
@@ -57,6 +59,34 @@ say`Signed in as ${user.profile.name ?? 'Anonymous'}`; // → "Signed in as {0}"
 ```
 
 Pull values into local variables before interpolating them, translators get readable placeholders, and the message stays stable across refactors.
+
+When you cannot, name the placeholder by interpolating a single-key object, the key is the name:
+
+```ts
+say`Your total is ${{ cartTotal: getCartTotal() }}`; // → "Your total is {cartTotal}"
+```
+
+Nothing to import, and nothing survives the build, the transform reads the key and compiles only the
+value. Name the placeholder after what the value is to the sentence, `cartTotal`, `dueDate`, not
+after the expression that produced it, a translator sees only the name and the words around it.
+
+The name must be a valid identifier: a letter or underscore followed by letters, digits, or
+underscores. An invalid name fails the build. Naming is opt-in and per placeholder, so anything you
+leave alone keeps its number. It works in `say.plural`, `say.ordinal` and `say.select` selectors
+too, and in `<Say>` interpolations:
+
+```tsx
+say.plural({ items: cart.length }, { one: '# item', other: '# items' });
+
+<Say>Signed in as {{ who: user.profile.name }}</Say>;
+```
+
+<Callout type="info">
+  Only an object written inline with exactly one key is read as a name. A variable holding an object
+  (`` say`${data}` ``) is a value like any other, and so is an object with two keys, a spread, or a
+  computed key. Interpolating an object was never meaningful, it stringifies to `[object Object]`,
+  so nothing that used to work changes meaning.
+</Callout>
 
 ## Plurals
 

--- a/website/content/core-concepts/runtime.mdx
+++ b/website/content/core-concepts/runtime.mdx
@@ -190,12 +190,12 @@ Compiled macros end up calling `say.call(descriptor)`:
 ```ts
 say.call({
   id: 'abc123',
-  name: 'Ada',
+  _name: 'Ada',
 });
 // → "Hello, Ada!"
 ```
 
-In application code you rarely write this directly, the build transform generates it from your `` say`...` `` and `<Say>` macros. The descriptor always has an `id`; extra properties become ICU placeholders.
+In application code you rarely write this directly, the build transform generates it from your `` say`...` `` and `<Say>` macros. The descriptor always has an `id`; extra properties become ICU placeholders. The transform emits each value behind one underscore so it cannot collide with the descriptor's own keys, and `call` strips exactly one back off, keys written without one are passed through unchanged.
 
 ## Putting it together
 

--- a/website/content/guides/custom-transformer.mdx
+++ b/website/content/guides/custom-transformer.mdx
@@ -66,6 +66,9 @@ For reference, the JS transformer:
    - If it is one, builds a `CompositeMessage` from the AST.
 4. On `extract`, collects every `CompositeMessage` and converts each to the `Message` shape (with ICU string, comments, references).
 5. On `transform`, replaces each matched expression with a `say.call({ id, ...args })` call expression.
+   The built-in transformers emit each value behind an underscore (`_name`) to keep it out of the
+   descriptor's namespace, but that is a convention of theirs, not a requirement, `call` passes
+   unprefixed keys through unchanged.
 
 The JSX transformer does the same plus a `JSXElement` visitor for `<Say>` components.
 

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -58,6 +58,8 @@ Name the tag after what it does to the text, `bold`, `link`, `icon`, not after t
 
 Naming is opt-in and per element, so untagged elements keep their numbers alongside named ones. A tag must be a static string, and a valid identifier: a letter or underscore followed by letters, digits, or underscores.
 
+`say-tag` names elements. To name a value you interpolate, wrap it in a single-key object: `<Say>Signed in as {{ who: user.profile.name }}</Say>`. See [Placeholder names](/core-concepts/messages#placeholder-names).
+
 Two tagged elements in one message can share a name as long as they are identical, the same element
 with the same props, as `<b say-tag="bold">` twice is. They compile to one prop, and a translator
 still sees a single `<bold>` they can move around the sentence. Only the props are compared, not the

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -58,7 +58,7 @@ Name the tag after what it does to the text, `bold`, `link`, `icon`, not after t
 
 Naming is opt-in and per element, so untagged elements keep their numbers alongside named ones. A tag must be a static string, and a valid identifier: a letter or underscore followed by letters, digits, or underscores.
 
-`say-tag` names elements. To name a value you interpolate, wrap it in a single-key object: `<Say>Signed in as {{ who: user.profile.name }}</Say>`. See [Placeholder names](/core-concepts/messages#placeholder-names).
+`say-tag` names elements. To name a value you interpolate, wrap it in a single-key object: `<Say>Signed in as {{ who: user.profile.name }}</Say>`. Values follow the same rule as tags, a repeat is fine when it is the same value and a build error when it is not. See [Placeholder names](/core-concepts/messages#placeholder-names).
 
 Two tagged elements in one message can share a name as long as they are identical, the same element
 with the same props, as `<b say-tag="bold">` twice is. They compile to one prop, and a translator

--- a/website/content/integrations/vite.mdx
+++ b/website/content/integrations/vite.mdx
@@ -120,7 +120,7 @@ The plugin takes no options, everything it needs lives in your `saykit.config.ts
 
 ## What it does
 
-For every file in your bucket's `include` globs, the plugin asks the configured transformers to rewrite the source. Macros like `` say`Hello, ${name}!` `` become small `say.call({ id: '...', name })` runtime invocations.
+For every file in your bucket's `include` globs, the plugin asks the configured transformers to rewrite the source. Macros like `` say`Hello, ${name}!` `` become small `say.call({ id: '...', _name: name })` runtime invocations.
 
 For every import that matches a bucket's `output` template, e.g. `import fr from './locales/fr.po'`, the plugin resolves that locale's [fallback chain](/core-concepts/configuration#fallback-locales), parses each file in it with the bucket's formatter, and emits a single JS module exporting the merged catalogue, real translations overlaying their fallbacks, untranslated keys resolving to the source string. There is no `.po` file at runtime; just plain JS objects, and still only one locale per module. Each source file in the chain is registered as a watch dependency, so editing the source locale re-runs the load for dependent locales in dev.
 

--- a/website/content/reference/api/saykit.mdx
+++ b/website/content/reference/api/saykit.mdx
@@ -134,6 +134,11 @@ say.call({ id: 'abc123', name: 'Ada' }); // → "Hello, Ada!"
 
 The descriptor must have an `id`. Extra properties are ICU placeholder values.
 
+The transform emits each value behind one underscore (`{ id: 'abc123', _name: 'Ada' }`), which keeps
+a message's values in their own namespace, so a value named `id` cannot displace the message being
+looked up. `call` strips exactly one underscore back off, and passes keys written without one
+through untouched, so a hand-written or custom-transformer-generated call works either way.
+
 In normal application code, you don't write this, the build transform emits it from your `` say`...` `` macros.
 
 ### Iteration
@@ -198,6 +203,20 @@ say.select(gender, {
   other: 'They liked it',
 });
 ```
+
+### Named placeholders
+
+Interpolating a single-key object names the placeholder that value becomes, for the values that
+would otherwise be numbered. The wrapper is read at build time and never reaches the bundle.
+
+```ts
+say`Your total is ${{ cartTotal: getCartTotal() }}`; // → "Your total is {cartTotal}"
+
+say.plural({ items: cart.length }, { one: '# item', other: '# items' });
+```
+
+The name must be a valid identifier, an invalid one fails the build. See
+[Placeholder names](/core-concepts/messages#placeholder-names).
 
 ## Types
 


### PR DESCRIPTION
Closes #67. Targets `main`, with #66 merged in — this extends its underscore convention from JSX to plain JS.

Two gaps in the plain-JS pipeline: placeholders that cannot be named, and a value named `id` silently breaking the message lookup.

## Naming a placeholder

An interpolated variable is already named after itself, so only the values that would otherwise be numbered need anything. Interpolate a single-key object and the key is the name:

```ts
say`Your total is ${{ cartTotal: getCartTotal() }}`; // → "Your total is {cartTotal}"
```

Nothing to import, and nothing survives the build — the transform reads the key and compiles only the value. It works the same in `say.plural`/`ordinal`/`select` selectors and in `<Say>` interpolations:

```tsx
say.plural({ items: cart.length }, { one: '# item', other: '# items' });

<Say>Signed in as {{ who: user.profile.name }}</Say>
```

### What is and is not claimed

Only an object written inline with exactly one non-computed key whose value is an expression. A variable holding an object, an object with two keys, a spread, a computed key, and a method are all left exactly as they were:

```js
say`Data ${data} ${{ a: 1, b: 2 }}`; // → say.call({ id: "lnR_iw", _data: data, _0: { a: 1, b: 2 } })
```

This is the reason for choosing the shape: interpolating an object stringifies to `[object Object]` and rendering one in JSX throws, so there is no working code whose meaning changes. A function macro (`ph('name', value)`) was the alternative, and was rejected because it needs an import, is matched by name, and can be shadowed.

The name must be a valid identifier — a letter or underscore followed by letters, digits, or underscores — matching the rule `say-tag` uses. An invalid one fails the build rather than producing an unusable ICU name. Naming is opt-in per placeholder, so anything left alone keeps its number.

Recognition lives in one exported function, `unwrapPlaceholder` in `@saykit/transform-js/parser`, which `@saykit/transform-jsx` imports at all three sites that used to derive an identifier from an expression; its duplicate local helper is deleted rather than taught the same trick twice.

## A value named `id` no longer breaks the lookup

`generateSayCallExpression` built one flat object, so a value named `id` emitted a duplicate key and won:

```js
say`Hi ${id}`; // → say.call({ id: "sF5gu7", id: id })
```

`descriptor.id` became the runtime value of the variable, so `messages[descriptor.id]` missed and threw `Message for <value> is not a string` — at runtime, in whichever locale happened to be active, with no build-time signal.

Values are now compiled behind one underscore and `Say#call` strips exactly one back off, the same convention #66 introduced for JSX props:

```js
say`Hi ${id} and ${name}`; // → say.call({ id: "sF5gu7", _id: id, _name: name })
```

Keys written without an underscore are passed through untouched, so hand-written calls and custom transformers that emit `say.call({ id, ...values })` keep working — `examples/custom-formatter` does exactly that and is the end-to-end proof. `@saykit/react` stops stripping before it calls `say.call` and passes its props through prefixed, so there is exactly one strip in the pipeline and double-stripping is structurally impossible rather than a convention.

The generator also dedupes repeated identifiers now, so `` say`${a} and ${a}` `` emits one property instead of a duplicate key. Side benefit: `_0` is a real identifier, where `t.identifier('0')` only worked because `@babel/generator` prints the name raw.

## Types

`say.plural(_: number, …)` would reject `{ items: cart.length }`, so the three selector parameters widened to `number | Named<number>` (and `string | Named<string>`) in both the `Say` class and `Say.Plural`/`Ordinal`/`Select`. `Named<T>` is a new export from `saykit`. This is the one cost of the syntax: those parameters are looser than they were, since TypeScript cannot express "an object with exactly one key". The build-time check is what actually validates the shape.

## Breaking

- `{id}` in a message is now fed by `_id` rather than resolving to the message's own id, which was never useful.
- A hand-written value literally named `_foo` must be written `__foo`.
- `saykit`, `@saykit/transform-js`, `@saykit/transform-jsx` and `@saykit/react` must be released together: a transform emitting `_id` against a runtime that does not strip it renders wrong output. The `saykit` peer range in `@saykit/react` is `"*"`, so npm will not catch a mismatched pair — worth tightening separately.

## Verification

- 368 tests pass (31 new); `pnpm -r check`, `oxlint` and the website build are clean.
- Compiled output checked directly for every case above, including the negative ones.
- `examples/vanilla` and `examples/react` re-extract with no catalogue churn; the vanilla bundle now contains `call({id:"pOt5xO",_0:Math.abs(...)})` and still builds.
- `examples/custom-formatter`, which hand-writes `say.call({ id, ...values })` with unprefixed keys, still renders correctly.

## Duplicate names

A name belongs to a value, not a position, so the rule is the one #66 gave elements: same name, the expressions must match, or it is a build error.

```js
say`${name} invited ${name}'s team`; // one value, one prop
say`${{ total: cart.total }} of ${{ total: cart.total }}`; // one value, one prop
say`${{ n: items.length }} ${{ n: users.length }}`; // error
say`${name} ${{ name: author.name }}`; // error
```

No implicit/explicit distinction is needed: an implicit name is only ever a bare identifier, so two implicit collisions are the same variable by construction, and reusing `${name}` stays free. `${{ name: name }}` beside `${name}` is also legal, since it is the same value written two ways.

`collectAssignedIdentifiers` now claims value names through the same comparison it already used for tags, and `isEquivalentElement` is replaced by `isEquivalentPlaceholder` in `@saykit/transform-js/parser`: elements compare on their opening element alone, everything else compares whole. Both transformers pass it — `transform-js` passed no comparator at all before, which would have made the legal repeat an error.

One consequence worth stating: a repeat is evaluated once, so `${{ total: getTotal() }}` twice calls `getTotal` once. Documented rather than restricted, so the rule stays one sentence.

## Not in scope

Nothing outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named placeholders using inline single-key objects (e.g. `{ who: name }`) across message macros and JSX.
  * Expanded plural, ordinal, and select macros to accept named numeric/string values.
* **Bug Fixes**
  * Improved placeholder handling with underscore-prefixed descriptor values, including safe stripping of exactly one leading underscore.
  * Prevented collisions with message metadata and tag names; added stricter protection against invalid names and unsafe/inherited placeholder properties.
* **Documentation**
  * Updated guides and references to reflect the underscore-based placeholder naming and runtime lookup behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
