### PR TITLE
Accept named placeholders as Say children

### DIFF
--- a/.changeset/tidy-owls-relate.md
+++ b/.changeset/tidy-owls-relate.md
@@ -1,0 +1,5 @@
+---
+'@saykit/react': patch
+---
+
+Accept named placeholders as `Say` children

--- a/packages/integration-react/src/runtime/index.ts
+++ b/packages/integration-react/src/runtime/index.ts
@@ -2,13 +2,16 @@ import {
   cloneElement,
   createElement,
   isValidElement,
-  type PropsWithChildren,
   type ReactElement,
   type ReactNode,
 } from 'react';
 import type { Disallow, Named, NumeralOptions, SelectOptions } from 'saykit';
 import { Renderer } from '~/components/renderer.js';
-import { type PropsWithJSXSafeKeys, resolveValuePropKeys } from '~/types.js';
+import {
+  type PropsWithJSXSafeKeys,
+  type PropsWithSayChildren,
+  resolveValuePropKeys,
+} from '~/types.js';
 
 declare function GET_SAY(): import('saykit').ReadonlySay;
 
@@ -21,7 +24,7 @@ declare function GET_SAY(): import('saykit').ReadonlySay;
  */
 // @ts-expect-error macro
 export function Say(
-  props: PropsWithChildren<Disallow<{ context?: string; whitespace?: boolean }, 'id'>>,
+  props: PropsWithSayChildren<Disallow<{ context?: string; whitespace?: boolean }, 'id'>>,
 ): ReactElement;
 export function Say(props: { id: string; whitespace?: boolean; [match: string]: unknown }) {
   if (!('id' in props))

--- a/packages/integration-react/src/types.ts
+++ b/packages/integration-react/src/types.ts
@@ -1,3 +1,17 @@
+import type { ReactNode } from 'react';
+import type { Named } from 'saykit';
+
+/**
+ * What a message is allowed to contain. On top of everything React renders, a
+ * named placeholder — `{{ name: value }}` — reaches the type checker as a plain
+ * object child, so the object form has to be part of the contract even though
+ * nothing ever renders it: the transform reads the name off it and compiles the
+ * child away before React sees the tree.
+ */
+export type SayNode = ReactNode | Named<unknown> | Iterable<SayNode>;
+
+export type PropsWithSayChildren<P = unknown> = P & { children?: SayNode };
+
 export type PropsWithJSXSafeKeys<T> = {
   [K in keyof T as K extends number | `${number}${string}`
     ? `_${K}`


### PR DESCRIPTION
Fixes #70

`Say`'s `children` was typed as `ReactNode`, which excludes the plain object a named placeholder — `{{ query: settled }}` — reaches the type checker as, so any message using one failed to type check.

Adds `SayNode`/`PropsWithSayChildren` in the React package's types and uses them for `Say`. The object form is only ever a type-level concern: the transform reads the name off it and compiles the child away before React sees the tree.

Verified with `tsc --noEmit` over the issue's repro plus plain-text and mixed element/placeholder children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `Say` components now accept named placeholders as children.
  * Children can include React content and nested combinations of supported values.
* **Bug Fixes**
  * Improved compatibility and type checking for messages using named placeholders, helping prevent valid usage from being rejected during development.
* **Release**
  * Patch release prepared for `@saykit/react`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->