### PR TITLE
Stop JSX extraction inserting a space before stranded punctuation

### DIFF
--- a/.changeset/lucky-melons-shave.md
+++ b/.changeset/lucky-melons-shave.md
@@ -1,0 +1,5 @@
+---
+"@saykit/transform-jsx": patch
+---
+
+Stop JSX extraction inserting a space before punctuation stranded at the start of a line.

--- a/packages/integration/src/runtime.test.ts
+++ b/packages/integration/src/runtime.test.ts
@@ -65,10 +65,7 @@ describe('Say.locale getter', () => {
 });
 
 describe('Say.messages getter', () => {
-  it('returns the messages for the active locale', () => {
-    expect(make('en').messages).toEqual(messages.en);
-  });
-
+  // The active-locale case is covered by the constructor test above.
   it('throws when no locale is active', () => {
     expect(() => make().messages).toThrow('No active locale');
   });
@@ -212,32 +209,19 @@ describe('Say iteration', () => {
 });
 
 describe('Say.match', () => {
-  it('returns the first locale when no guesses are given', () => {
-    expect(make().match()).toBe('en');
-  });
-
-  it('returns the first locale when guesses are empty arrays', () => {
-    expect(make().match([])).toBe('en');
-  });
-
-  it('returns an exact match', () => {
-    expect(make().match('fr')).toBe('fr');
-  });
-
-  it('flattens array guesses', () => {
-    expect(make().match(['zz', 'fr'])).toBe('fr');
-  });
-
-  it('matches on the language prefix', () => {
-    expect(make().match('fr-CA')).toBe('fr');
-  });
-
-  it('skips guesses with an empty prefix', () => {
-    expect(make().match('', 'de')).toBe('de');
-  });
-
-  it('falls back to the first locale when nothing matches', () => {
-    expect(make().match('zz', 'xx-YY')).toBe('en');
+  // Locales are ['en', 'fr', 'de'], so 'en' is the first-locale fallback.
+  it.each([
+    ['no guesses are given', [], 'en'],
+    ['guesses are empty arrays', [[]], 'en'],
+    ['a guess matches exactly', ['fr'], 'fr'],
+    ['a guess is nested in an array', [['zz', 'fr']], 'fr'],
+    ['a guess matches on language prefix', ['fr-CA'], 'fr'],
+    ['a guess has an empty prefix', ['', 'de'], 'de'],
+    ['nothing matches', ['zz', 'xx-YY'], 'en'],
+  ])('resolves the locale when %s', (_, guesses, expected) => {
+    expect(make().match(...(guesses as Parameters<ReturnType<typeof make>['match']>))).toBe(
+      expected,
+    );
   });
 });
 
@@ -318,21 +302,13 @@ describe('Say inspect', () => {
 describe('Say macros', () => {
   const say = make('en');
 
-  it('throws for plural', () => {
-    expect(() => say.plural(1, { other: '#' })).toThrow(
-      "'Say#plural' is a macro and must be used with the relevant saykit plugin",
-    );
-  });
-
-  it('throws for ordinal', () => {
-    expect(() => say.ordinal(1, { other: '#' })).toThrow(
-      "'Say#ordinal' is a macro and must be used with the relevant saykit plugin",
-    );
-  });
-
-  it('throws for select', () => {
-    expect(() => say.select('a', { other: 'b' })).toThrow(
-      "'Say#select' is a macro and must be used with the relevant saykit plugin",
+  it.each([
+    ['plural', () => say.plural(1, { other: '#' })],
+    ['ordinal', () => say.ordinal(1, { other: '#' })],
+    ['select', () => say.select('a', { other: 'b' })],
+  ])('throws for %s', (name, call) => {
+    expect(call).toThrow(
+      `'Say#${name}' is a macro and must be used with the relevant saykit plugin`,
     );
   });
 });

--- a/packages/transform-js/src/parser.test.ts
+++ b/packages/transform-js/src/parser.test.ts
@@ -141,39 +141,59 @@ describe('parseTaggedTemplateExpression', () => {
 });
 
 describe('parseCallExpression', () => {
-  it('parses a simple plural call expression', () => {
-    const result = parser.parseCallExpression(
-      expr("say.plural(count, { one: 'item', other: 'items' })"),
-    );
-    expect(result).not.toBeNull();
+  // Every choice kind parses through one code path, so they are asserted as a
+  // table: the kind, the selector, and the branch list read off it.
+  it.each([
+    [
+      "say.plural(count, { one: 'item', other: 'items' })",
+      'plural',
+      'count',
+      [
+        ['one', 'item'],
+        ['other', 'items'],
+      ],
+    ],
+    [
+      "say.ordinal(position, { 1: 'first', 2: 'second', other: 'other' })",
+      'ordinal',
+      'position',
+      [
+        ['1', 'first'],
+        ['2', 'second'],
+        ['other', 'other'],
+      ],
+    ],
+    [
+      "say.select(gender, { male: 'He', female: 'She', other: 'They' })",
+      'select',
+      'gender',
+      [
+        ['male', 'He'],
+        ['female', 'She'],
+        ['other', 'They'],
+      ],
+    ],
+    [
+      // Numeric keys stay exact matches rather than becoming plural categories.
+      "say.plural(count, { 0: 'none', 1: 'one', other: 'many' })",
+      'plural',
+      'count',
+      [
+        ['0', 'none'],
+        ['1', 'one'],
+        ['other', 'many'],
+      ],
+    ],
+  ])('parses %s', (code, kind, identifier, branches) => {
+    const result = parser.parseCallExpression(expr(code));
     expect(result!.children).toHaveLength(1);
     const choice = result!.children[0] as ChoiceMessage;
     expect(choice).toBeInstanceOf(ChoiceMessage);
-    expect(choice.kind).toBe('plural');
-    expect(choice.identifier).toBe('count');
-    expect(choice.branches).toHaveLength(2);
-    expect(choice.branches[0]!.identifier).toBe('one');
-    expect(choice.branches[0]!.value).toEqual({ text: 'item' });
-    expect(choice.branches[1]!.identifier).toBe('other');
-    expect(choice.branches[1]!.value).toEqual({ text: 'items' });
-  });
-
-  it('parses an ordinal call expression', () => {
-    const result = parser.parseCallExpression(
-      expr("say.ordinal(position, { 1: 'first', 2: 'second', other: 'other' })"),
+    expect(choice.kind).toBe(kind);
+    expect(choice.identifier).toBe(identifier);
+    expect(choice.branches.map((b) => [b.identifier, (b.value as LiteralMessage).text])).toEqual(
+      branches,
     );
-    expect(result).not.toBeNull();
-    const choice = result!.children[0] as ChoiceMessage;
-    expect(choice).toBeInstanceOf(ChoiceMessage);
-    expect(choice.kind).toBe('ordinal');
-    expect(choice.identifier).toBe('position');
-    expect(choice.branches).toHaveLength(3);
-    expect(choice.branches[0]!.identifier).toBe('1');
-    expect(choice.branches[0]!.value).toEqual({ text: 'first' });
-    expect(choice.branches[1]!.identifier).toBe('2');
-    expect(choice.branches[1]!.value).toEqual({ text: 'second' });
-    expect(choice.branches[2]!.identifier).toBe('other');
-    expect(choice.branches[2]!.value).toEqual({ text: 'other' });
   });
 
   it('reads string-literal (quoted) choice keys', () => {

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -35,15 +35,8 @@ describe('parseJSXContainerElement', () => {
     expect(result!.children[0]).toEqual(new LiteralMessage('Hello'));
   });
 
-  it('normalises whitespace in text children', () => {
-    const result = parser.parseJSXContainerElement(jsx`
-      <Say>
-        Hello,
-        world!
-      </Say>
-    `);
-    expect((result!.children[0] as LiteralMessage).text).toBe('Hello, world!');
-  });
+  // Whitespace normalisation is covered end-to-end in `whitespace.test.ts`,
+  // where the assertions read as the catalogue strings it produces.
 
   it('parses expression children as ArgumentMessage', () => {
     const result = parser.parseJSXContainerElement(jsx`<Say>{name}</Say>`);
@@ -86,14 +79,10 @@ describe('parseJSXContainerElement', () => {
     expect(result!.descriptor.id).toBeUndefined();
   });
 
-  it('ignores a whitespace attribute whose value is not a boolean literal', () => {
-    const result = parser.parseJSXContainerElement(jsx`<Say whitespace={dynamic}>Hi</Say>`);
-    expect(result!.whitespace).toBeUndefined();
-  });
-
-  it('leaves descriptor fields undefined when attributes are absent', () => {
+  it('leaves descriptor and whitespace undefined when attributes are absent', () => {
     const result = parser.parseJSXContainerElement(jsx`<Say>Hi</Say>`);
     expect(result!.descriptor).toEqual({ id: undefined, context: undefined });
+    expect(result!.whitespace).toBeUndefined();
   });
 
   it('ignores spread attributes when reading descriptors and whitespace', () => {
@@ -102,19 +91,18 @@ describe('parseJSXContainerElement', () => {
     expect(result!.whitespace).toBeUndefined();
   });
 
-  it('leaves whitespace undefined when the attribute is absent', () => {
-    const result = parser.parseJSXContainerElement(jsx`<Say>Hi</Say>`);
-    expect(result!.whitespace).toBeUndefined();
-  });
-
-  it('reads whitespace={false} attribute as a boolean', () => {
-    const result = parser.parseJSXContainerElement(jsx`<Say whitespace={false}>Hi</Say>`);
-    expect(result!.whitespace).toBe(false);
-  });
-
-  it('treats a bare whitespace attribute as true', () => {
-    const result = parser.parseJSXContainerElement(jsx`<Say whitespace>Hi</Say>`);
-    expect(result!.whitespace).toBe(true);
+  // Only a boolean literal (or the bare attribute) sets it; anything else is
+  // only known at runtime, too late to change what is extracted.
+  it.each([
+    ['whitespace', true],
+    ['whitespace={true}', true],
+    ['whitespace={false}', false],
+    ['whitespace={dynamic}', undefined],
+  ])('reads `%s` as %s', (attribute, expected) => {
+    const element = parseExpression(`<Say ${attribute}>Hi</Say>`, {
+      plugins: ['jsx', 'typescript'],
+    }) as unknown as t.JSXElement;
+    expect(parser.parseJSXContainerElement(element)!.whitespace).toBe(expected);
   });
 });
 

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -28,9 +28,7 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
 
   const children = element.children.reduce<Message[]>((p, c, i, a) => {
     if (t.isJSXText(c)) {
-      let text = c.value.replace(/\s+/g, ' ');
-      if (i === 0) text = text.trimStart();
-      if (i === a.length - 1) text = text.trimEnd();
+      const text = normalizeJSXText(c.value, i === 0, i === a.length - 1);
       if (text) p.push(new LiteralMessage(text));
     }
 
@@ -130,6 +128,45 @@ export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeM
   }
 
   return null;
+}
+
+/**
+ * Punctuation that never takes a space in front of it. A formatter wrapping
+ * long JSX regularly strands these at the start of a line, on their own or
+ * ahead of the rest of a clause.
+ */
+const CLOSING_PUNCTUATION = /^[.,;:!?)\]}»”’]/;
+
+/**
+ * Collapse the whitespace in a JSX text child the way the source reads.
+ *
+ * A line break between a word and its neighbour is only how a formatter wrapped
+ * a long line, so it still means a space. Dropping it would run the words
+ * together — and because ids are content hashes, silently orphan every existing
+ * translation for the message.
+ *
+ * The exception is a line that begins with punctuation, which belongs tight
+ * against whatever precedes it. Only an implicit break is treated this way: a
+ * space the author wrote on the same line is deliberate and always survives.
+ */
+function normalizeJSXText(value: string, isFirst: boolean, isLast: boolean) {
+  let text = value.replace(/\s+/g, ' ');
+
+  if (isFirst) {
+    text = text.trimStart();
+  } else if (
+    text.startsWith(' ') &&
+    // The leading whitespace spans a line break, so it is the formatter's,
+    // not the author's.
+    /^[^\S\n]*\n/.test(value) &&
+    CLOSING_PUNCTUATION.test(text.slice(1))
+  ) {
+    text = text.slice(1);
+  }
+
+  if (isLast) text = text.trimEnd();
+
+  return text;
 }
 
 function processJSXOpeningElement(element: t.JSXOpeningElement): [t.Node, string | null] | null {

--- a/packages/transform-jsx/src/whitespace.test.ts
+++ b/packages/transform-jsx/src/whitespace.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import createJsxTransformer from './index.js';
+
+const transformer = createJsxTransformer();
+
+// Extraction is the level these regressions are actually observed at: the
+// strings asserted below are byte-for-byte the msgids and catalogue values that
+// land in `examples/*/src/locales/*`. A whitespace change that survives the
+// parser but corrupts a catalogue has to fail here.
+function extract(jsx: string) {
+  return transformer.extract(`const x = ${jsx};`, 'file.tsx')[0]?.message;
+}
+
+/**
+ * Prettier wraps JSX at the print width, so a translatable line routinely ends
+ * with a word and continues with an element on the next line. The line break is
+ * the only thing separating them, and it has to keep meaning "space" — dropping
+ * it runs the words together and, because ids are content hashes, silently
+ * orphans every existing translation for the message.
+ *
+ * Each case below is lifted from a real example app, named by where it lives.
+ * They exist because they are the shapes that regressed in #63 while the whole
+ * suite stayed green.
+ */
+describe('whitespace across a line break', () => {
+  it('joins text to an element on the next line', () => {
+    // examples/react/src/components/board.tsx
+    expect(
+      extract(`<Say>
+        Nothing here. <a href="#new">Add a task</a> or drag one across from
+        <strong>To do</strong>.
+      </Say>`),
+    ).toBe('Nothing here. <0>Add a task</0> or drag one across from <1>To do</1>.');
+  });
+
+  it('joins text between two elements that each start a line', () => {
+    // examples/expo/src/habit-card.tsx
+    expect(
+      extract(`<Say>
+        <Text style={s}>{a}</Text> of
+        <Text style={s}>{b}</Text> this week
+      </Say>`),
+    ).toBe('<0>{a}</0> of <1>{b}</1> this week');
+  });
+
+  it('joins text to a choice element on both sides', () => {
+    // examples/tanstack-start/src/routes/{-$locale}/index.tsx
+    expect(
+      extract(`<Say>
+        their
+        <Say.Ordinal _={n} one="#st" two="#nd" few="#rd" other="#th" />
+        time on this stage
+      </Say>`),
+    ).toBe(`their {n, selectordinal,
+  one {#st}
+  two {#nd}
+  few {#rd}
+  other {#th}
+} time on this stage`);
+  });
+
+  it('joins text to two consecutive choice elements', () => {
+    // examples/tanstack-start/src/routes/{-$locale}/index.tsx
+    expect(
+      extract(`<Say>
+        The full program —
+        <Say.Plural _={s} one="# session" other="# sessions" />, including
+        <Say.Plural _={w} one="# workshop" other="# workshops" />.
+      </Say>`),
+    ).toBe(`The full program — {s, plural,
+  one {# session}
+  other {# sessions}
+}, including {w, plural,
+  one {# workshop}
+  other {# workshops}
+}.`);
+  });
+});
+
+describe('whitespace on a single line', () => {
+  it('keeps single spaces around an element', () => {
+    expect(extract('<Say>Hello <strong>brave</strong> world!</Say>')).toBe(
+      'Hello <0>brave</0> world!',
+    );
+  });
+
+  it('collapses a run of spaces to one', () => {
+    expect(extract('<Say>Hello   <strong>brave</strong>   world!</Say>')).toBe(
+      'Hello <0>brave</0> world!',
+    );
+  });
+
+  it('keeps no space where the source has none', () => {
+    expect(extract('<Say>(<strong>brave</strong>)</Say>')).toBe('(<0>brave</0>)');
+  });
+});
+
+describe('whitespace at the container edges', () => {
+  it('trims the indentation a multiline container introduces', () => {
+    expect(
+      extract(`<Say>
+        Hello, world!
+      </Say>`),
+    ).toBe('Hello, world!');
+  });
+
+  it('joins wrapped lines of plain text with a single space', () => {
+    expect(
+      extract(`<Say>
+        Hello,
+        world!
+      </Say>`),
+    ).toBe('Hello, world!');
+  });
+
+  it('trims around a leading and trailing element', () => {
+    expect(
+      extract(`<Say>
+        <strong>Hello</strong>, world
+      </Say>`),
+    ).toBe('<0>Hello</0>, world');
+  });
+});
+
+/**
+ * The counterpart to the block above: a line break usually means a space, but
+ * punctuation belongs tight against what precedes it. A formatter wrapping long
+ * JSX strands punctuation at the start of a line routinely, and a space in
+ * front of it would ship to every locale.
+ */
+describe('punctuation at the start of a line', () => {
+  it('takes no space before a full stop left on its own line', () => {
+    expect(
+      extract(`<Say>
+        Kiai Security — only authorize apps you trust. Report malicious
+        integrations in
+        <a href="https://discord.gg/example">our support server</a>
+        .
+      </Say>`),
+    ).toBe(
+      'Kiai Security — only authorize apps you trust. Report malicious integrations in <0>our support server</0>.',
+    );
+  });
+
+  it('takes no space before a clause that opens with a comma', () => {
+    expect(
+      extract(`<Say>
+        Signed,
+        <strong>the team</strong>
+        , with thanks
+      </Say>`),
+    ).toBe('Signed, <0>the team</0>, with thanks');
+  });
+
+  it('keeps a space the author wrote on the same line', () => {
+    // Only an implicit line break is collapsed away; this space is deliberate.
+    expect(extract('<Say>Ready <strong>set</strong> ?</Say>')).toBe('Ready <0>set</0> ?');
+  });
+
+  it('keeps a space before an opening bracket on the next line', () => {
+    expect(
+      extract(`<Say>
+        See <a href="/d">the docs</a>
+        (they are short)
+      </Say>`),
+    ).toBe('See <0>the docs</0> (they are short)');
+  });
+});


### PR DESCRIPTION
## Summary

JSX text whitespace had ~no behavioural coverage: `transform-jsx/parser.ts` sat at 97% line coverage, but every test *executed* the whitespace code and none *asserted* on it. Rewriting the rules could go green. This adds that coverage, then fixes a bug it exposed.

## The fix

Punctuation stranded at the start of a line gained a space in front of it, so a catalogue read `our support server .` and every locale shipped the stray space.

A line break has to keep meaning "space" — it is only how a formatter wrapped a long line, and dropping it runs words together and (because ids are content hashes) orphans every existing translation. So the rule is conditional: drop the space only when the whitespace spans a newline **and** the next character is closing punctuation.

The newline test is what makes it safe — a space the author typed on the same line has no break in it, so deliberate spacing always survives.

## Coverage

New `packages/transform-jsx/src/whitespace.test.ts` asserts at the extraction level, so the expected strings are byte-for-byte the msgids that land in `examples/*/src/locales/*`. Cases are lifted from the real example apps and named by where they live: text→element across a break (`board.tsx`), text between two elements (`habit-card.tsx`), text around one and two choice elements (`index.tsx`), plus same-line, container-edge and punctuation cases.

Verified these actually bite: swapping in a Babel-faithful normaliser turns 7 of them red.

## Relationship to JSX semantics

Checked against `cleanJSXElementLiteralChild`, the function Babel's JSX transform uses. Same-line spacing and punctuation-on-its-own-line now match Babel exactly — this change moved us toward JSX semantics. The remaining divergence is one deliberate rule: an implicit line break means a space here, where Babel drops it.

That is safe because Babel's cleaner never sees this text. `generateSayJSXElement` emits a self-closing `<Say id="…" _0={…} />` with an empty children array, so the JSX text children are discarded at transform time and the renderer rebuilds from the catalogue string by raw slicing. The ICU string is the source of truth.

Caveat: the divergence is only invisible while the plugin is applied. A `<Say>` rendered untransformed (plugin misconfigured, file outside the bucket's `include` globs) would get React's rules instead.

## Test cleanup

No assertions lost, −102/+86 in existing files:

- `transform-js/parser.test.ts` — four near-identical choice tests (~70 lines of duplicated branch assertions) collapsed to one `it.each`
- `integration/runtime.test.ts` — macro and `Say.match` tests tabled; dropped a `Say.messages` test that re-asserted the constructor test verbatim
- `transform-jsx/parser.test.ts` — four `whitespace` attribute tests tabled; merged two overlapping "attributes absent" tests

## Tests

- `pnpm vitest run` — 401 passing, 33 files
- `pnpm turbo run check` — 18/18
- `oxlint` + `oxfmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSX message extraction so formatter-added line breaks and spaces are handled correctly.
  * Prevented unwanted spaces before punctuation at the beginning of lines.
  * Preserved intended spacing between words, inline elements, and explicitly authored spaces.

* **Tests**
  * Expanded coverage for whitespace, punctuation, brackets, line breaks, and JSX choices.
  * Consolidated validation for plural, ordinal, select, and numeric-key message patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->