### PR TITLE
Assemble catalogues in the bundler module pipeline so edits hot-reload

### DIFF
--- a/.changeset/fresh-owls-guess.md
+++ b/.changeset/fresh-owls-guess.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-saykit': minor
+---
+
+Add `babel-plugin-saykit/next`, a `withSayKit` wrapper that derives the Turbopack and webpack catalogue rules from your SayKit config

--- a/.changeset/hot-donkeys-shave.md
+++ b/.changeset/hot-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-saykit': minor
+---
+
+Assemble catalogues in the bundler's module pipeline via `babel-plugin-saykit/webpack` and `babel-plugin-saykit/metro` so editing one hot-reloads instead of requiring a cache-clearing restart

--- a/.changeset/hot-donkeys-shave.md
+++ b/.changeset/hot-donkeys-shave.md
@@ -2,4 +2,4 @@
 'babel-plugin-saykit': minor
 ---
 
-Assemble catalogues in the bundler's module pipeline via `babel-plugin-saykit/webpack` and `babel-plugin-saykit/metro` so editing one hot-reloads instead of requiring a cache-clearing restart
+Add a `catalogues: 'module'` option that hands catalogue assembly to `babel-plugin-saykit/webpack` or `babel-plugin-saykit/metro`, so editing a catalogue hot-reloads instead of requiring a cache-clearing restart

--- a/.changeset/hot-donkeys-shave.md
+++ b/.changeset/hot-donkeys-shave.md
@@ -2,4 +2,4 @@
 'babel-plugin-saykit': minor
 ---
 
-Add a `catalogues: 'module'` option that hands catalogue assembly to `babel-plugin-saykit/webpack` or `babel-plugin-saykit/metro`, so editing a catalogue hot-reloads instead of requiring a cache-clearing restart
+Add a `catalogues: 'module'` option that hands catalogue assembly to `babel-plugin-saykit/next` or `babel-plugin-saykit/metro`, so editing a catalogue hot-reloads instead of requiring a cache-clearing restart

--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -2,4 +2,4 @@
 '@saykit/config': minor
 ---
 
-Export `findConfigFile` and `getConfigFileCandidates` from `@saykit/config/features/loader`
+Export `resolveConfigFile` from `@saykit/config/features/loader`

--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@saykit/config': minor
+---
+
+Export `findConfigFile` and `getConfigFileCandidates` from `@saykit/config/features/loader`

--- a/.changeset/tidy-moons-agree.md
+++ b/.changeset/tidy-moons-agree.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-saykit': patch
+---
+
+Resolve Metro's upstream transformer from the config's `projectRoot`, and invalidate its transform cache when `saykit.config.*` changes

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,5 +21,5 @@
 
   // Code Spell Checker
   "cSpell.language": "en-GB",
-  "cSpell.words": ["saykit", "unplugin"]
+  "cSpell.words": ["saykit", "turbopack", "unplugin"]
 }

--- a/examples/babel/README.md
+++ b/examples/babel/README.md
@@ -1,0 +1,48 @@
+# Babel example
+
+SayKit compiled by **Babel and nothing else** — no bundler, no dev server, no loader.
+`babel src --out-dir dist`, then `node dist/main.js`.
+
+This exists to pin down the `catalogues: 'inline'` default: `babel-plugin-saykit` on its
+own has to rewrite the macros _and_ resolve the catalogue imports, with no other tool
+involved. Every other example runs the plugin alongside a bundler integration, so this is
+the only one that would notice if that stopped being true.
+
+## Run
+
+```sh
+pnpm start
+```
+
+```
+[en]
+Welcome to the library
+3 books on loan
+Your card expires soon
+
+[fr]
+Bienvenue à la bibliothèque
+3 livres empruntés
+Your card expires soon
+```
+
+The last line is untranslated in `fr.po`, so it resolves through the fallback chain to the
+English source string — merged in at compile time, not looked up at runtime.
+
+## What to look at
+
+| Thing                                                             | Where             |
+| ----------------------------------------------------------------- | ----------------- |
+| `plugins: ['saykit']`, no options — the inlining default          | `babel.config.js` |
+| `import en from './locales/en.po'`, gone by the time Node sees it | `src/main.ts`     |
+| The compiled record, one object literal per locale                | `dist/main.js`    |
+
+Open `dist/main.js` after a build: there is no `.po` file, no PO parser and no SayKit
+extractor in the output, just `const en = { … }` and `say.call()` invocations.
+
+## Hot reload
+
+There is none, by design. The record lands inside `dist/main.js`, whose own bytes only
+change when you rebuild — which is exactly why a dev server wants `catalogues: 'module'`
+and a bundler integration instead. See the
+[Babel integration docs](../../website/content/integrations/babel.mdx).

--- a/examples/babel/README.md
+++ b/examples/babel/README.md
@@ -1,7 +1,7 @@
 # Babel example
 
 SayKit compiled by **Babel and nothing else** — no bundler, no dev server, no loader.
-`babel src --out-dir dist`, then `node dist/main.js`.
+`pnpm build`, then `node dist/main.js`.
 
 This exists to pin down the `catalogues: 'inline'` default: `babel-plugin-saykit` on its
 own has to rewrite the macros _and_ resolve the catalogue imports, with no other tool
@@ -14,7 +14,7 @@ the only one that would notice if that stopped being true.
 pnpm start
 ```
 
-```
+```text
 [en]
 Welcome to the library
 3 books on loan

--- a/examples/babel/babel.config.js
+++ b/examples/babel/babel.config.js
@@ -1,0 +1,12 @@
+/**
+ * Babel and nothing else — no bundler, no loader, no `withSayKit`.
+ *
+ * `babel-plugin-saykit` with its defaults rewrites the macros *and* inlines the
+ * catalogue imports, so the compiled output in `dist/` is plain JavaScript with
+ * one object literal per locale and no `.po` file anywhere near it. That is the
+ * `catalogues: 'inline'` mode, and this example exists to keep it working.
+ */
+module.exports = {
+  presets: [['@babel/preset-env', { targets: { node: 'current' } }], '@babel/preset-typescript'],
+  plugins: ['saykit'],
+};

--- a/examples/babel/package.json
+++ b/examples/babel/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "babel-example",
+  "private": true,
+  "scripts": {
+    "check": "tsc --noEmit",
+    "extract": "saykit extract",
+    "build": "babel src --extensions .ts --out-dir dist --ignore \"src/**/*.d.po.ts\"",
+    "start": "pnpm build && node dist/main.js"
+  },
+  "dependencies": {
+    "saykit": "workspace:^"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.29.7",
+    "@babel/core": "^7.29.7",
+    "@babel/preset-env": "^7.29.7",
+    "@babel/preset-typescript": "^7.29.7",
+    "@saykit/config": "workspace:^",
+    "@saykit/format-po": "workspace:^",
+    "@saykit/transform-js": "workspace:^",
+    "babel-plugin-saykit": "workspace:^",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/babel/saykit.config.ts
+++ b/examples/babel/saykit.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@saykit/config';
+import po from '@saykit/format-po';
+import js from '@saykit/transform-js';
+
+export default defineConfig({
+  locales: ['en', 'fr'],
+  buckets: [
+    {
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.d.*.ts'],
+      output: 'src/locales/{locale}.{extension}',
+      formatter: po(),
+      transformer: [js()],
+    },
+  ],
+});

--- a/examples/babel/src/locales/en.d.po.ts
+++ b/examples/babel/src/locales/en.d.po.ts
@@ -1,0 +1,2 @@
+declare const messages: Record<string, string>;
+export default messages;

--- a/examples/babel/src/locales/en.po
+++ b/examples/babel/src/locales/en.po
@@ -1,0 +1,26 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"X-Generator: saykit\n"
+
+#: src/main.ts:17
+msgid ""
+"{books, plural,\n"
+"  one {# book on loan}\n"
+"  other {# books on loan}\n"
+"}"
+msgstr ""
+"{books, plural,\n"
+"  one {# book on loan}\n"
+"  other {# books on loan}\n"
+"}"
+
+#: src/main.ts:16
+msgid "Welcome to the library"
+msgstr "Welcome to the library"
+
+#: src/main.ts:20
+msgid "Your card expires soon"
+msgstr "Your card expires soon"

--- a/examples/babel/src/locales/fr.d.po.ts
+++ b/examples/babel/src/locales/fr.d.po.ts
@@ -1,0 +1,2 @@
+declare const messages: Record<string, string>;
+export default messages;

--- a/examples/babel/src/locales/fr.po
+++ b/examples/babel/src/locales/fr.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"X-Generator: saykit\n"
+
+msgid ""
+"{books, plural,\n"
+"  one {# book on loan}\n"
+"  other {# books on loan}\n"
+"}"
+msgstr ""
+"{books, plural,\n"
+"  one {# livre emprunté}\n"
+"  other {# livres empruntés}\n"
+"}"
+
+msgid "Welcome to the library"
+msgstr "Bienvenue à la bibliothèque"
+
+# Deliberately left untranslated, so the compiled `fr` record falls back to the
+# English source string.
+msgid "Your card expires soon"
+msgstr ""

--- a/examples/babel/src/main.ts
+++ b/examples/babel/src/main.ts
@@ -1,0 +1,22 @@
+import { Say } from 'saykit';
+import en from './locales/en.po';
+import fr from './locales/fr.po';
+
+const locales = ['en', 'fr'] as const;
+type Locale = (typeof locales)[number];
+
+const say = new Say<Locale>({ locales: [...locales], messages: { en, fr } });
+
+const books = 3;
+
+for (const locale of locales) {
+  say.activate(locale);
+
+  console.log(`[${locale}]`);
+  console.log(say`Welcome to the library`);
+  console.log(say.plural(books, { one: '# book on loan', other: '# books on loan' }));
+  // Untranslated in `fr`, so it falls back to the source locale — the Babel
+  // plugin merges the fallback chain into each record at compile time.
+  console.log(say`Your card expires soon`);
+  console.log();
+}

--- a/examples/babel/tsconfig.json
+++ b/examples/babel/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*", "saykit.config.ts"]
+}

--- a/examples/expo/babel.config.js
+++ b/examples/expo/babel.config.js
@@ -1,14 +1,15 @@
 /**
  * Metro compiles with Babel, so SayKit hooks in as a Babel plugin rather than a
- * bundler plugin. `babel-plugin-saykit` does the same two jobs `unplugin-saykit`
- * does elsewhere: rewrite the `<Say>` / `` say`…` `` macros, and inline
- * `import en from './locales/en.json'` as a plain object.
+ * bundler plugin, rewriting the `<Say>` / `` say`…` `` macros.
+ *
+ * Catalogues are left to `withSayKit` in `metro.config.js` — see the
+ * `catalogues` option — so that editing one hot-reloads.
  */
 module.exports = function babelConfig(api) {
   api.cache(true);
 
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['saykit'],
+    plugins: [['saykit', { catalogues: 'module' }]],
   };
 };

--- a/examples/expo/metro.config.js
+++ b/examples/expo/metro.config.js
@@ -1,7 +1,13 @@
 const path = require('node:path');
 const { getDefaultConfig } = require('expo/metro-config');
+const { withSayKit } = require('babel-plugin-saykit/metro');
 
-const config = getDefaultConfig(__dirname);
+// Metro never runs Babel over `.json`, so the catalogues are assembled by a
+// transformer rather than the Babel plugin. That also keeps them real modules,
+// which is what lets Metro invalidate them — its transform cache is keyed on
+// each file's own bytes, so a record inlined into an importer can never go
+// stale-free. See https://github.com/k0d13/saykit/issues/71.
+const config = withSayKit(getDefaultConfig(__dirname));
 
 // Workspace packages (e.g. @saykit/react) keep their own React devDependency,
 // which Metro would otherwise bundle as a second copy alongside the app's.

--- a/examples/nextjs/.babelrc
+++ b/examples/nextjs/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["next/babel"],
-  "plugins": ["saykit"]
+  "plugins": [["saykit", { "catalogues": "module" }]]
 }

--- a/examples/nextjs/next.config.mjs
+++ b/examples/nextjs/next.config.mjs
@@ -1,11 +1,7 @@
-export default {
-  turbopack: {
-    rules: { '*.po': { loaders: ['babel-plugin-saykit/webpack'], as: '*.js' } },
-  },
+import { withSayKit } from 'babel-plugin-saykit/next';
 
-  // Turbopack is the default, but `next --webpack` needs the same rule.
-  webpack: (config) => {
-    config.module.rules.push({ test: /\.po$/, use: 'babel-plugin-saykit/webpack' });
-    return config;
-  },
-};
+// Catalogues are served as real modules by a loader rather than inlined by the
+// Babel plugin (see `.babelrc`), which is what lets editing one hot-reload.
+// `withSayKit` derives the Turbopack and webpack rules from `saykit.config.ts`,
+// so they always match the buckets. See https://github.com/k0d13/saykit/issues/71.
+export default withSayKit({});

--- a/examples/nextjs/next.config.mjs
+++ b/examples/nextjs/next.config.mjs
@@ -1,0 +1,11 @@
+export default {
+  turbopack: {
+    rules: { '*.po': { loaders: ['babel-plugin-saykit/webpack'], as: '*.js' } },
+  },
+
+  // Turbopack is the default, but `next --webpack` needs the same rule.
+  webpack: (config) => {
+    config.module.rules.push({ test: /\.po$/, use: 'babel-plugin-saykit/webpack' });
+    return config;
+  },
+};

--- a/packages/config/src/features/loader/index.ts
+++ b/packages/config/src/features/loader/index.ts
@@ -1,1 +1,2 @@
+export { findConfigFile, getConfigFileCandidates } from './files.js';
 export { resolveConfig } from './resolve.js';

--- a/packages/config/src/features/loader/index.ts
+++ b/packages/config/src/features/loader/index.ts
@@ -1,2 +1,1 @@
-export { findConfigFile, getConfigFileCandidates } from './files.js';
-export { resolveConfig } from './resolve.js';
+export { resolveConfig, resolveConfigFile } from './resolve.js';

--- a/packages/config/src/features/loader/resolve.ts
+++ b/packages/config/src/features/loader/resolve.ts
@@ -3,15 +3,26 @@ import type { Config } from '~/shapes.js';
 import { findConfigFile } from './files.js';
 import { configLoaders } from './module.js';
 
-export function resolveConfig(name = 'saykit') {
+/**
+ * The config file {@link resolveConfig} would load, for callers that need the
+ * path itself rather than its contents — salting a bundler's cache key with it,
+ * for one, since what a catalogue assembles into depends on the config.
+ */
+export function resolveConfigFile(name = 'saykit') {
   const file = findConfigFile(name, process.cwd());
   if (!file) throw new Error(`Could not find config file for "${name}"`);
 
-  const ext = extname(file.id).toLowerCase();
+  return file.id;
+}
+
+export function resolveConfig(name = 'saykit') {
+  const id = resolveConfigFile(name);
+
+  const ext = extname(id).toLowerCase();
   const load = ext in configLoaders ? configLoaders[ext as keyof typeof configLoaders] : null;
   if (!load) throw new Error(`Unsupported config file type "${ext}" for "${name}"`);
 
-  const config = load(file.id);
+  const config = load(id);
   if (!config || typeof config !== 'object') throw new Error(`Invalid config file for "${name}"`);
 
   return config as Config;

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -27,16 +27,20 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.cjs",
+      "types": "./dist/index.d.cts",
       "default": "./dist/index.cjs"
     },
     "./metro": {
-      "types": "./dist/metro/index.d.cjs",
+      "types": "./dist/metro/index.d.cts",
       "default": "./dist/metro/index.cjs"
     },
-    "./webpack": {
-      "types": "./dist/webpack/index.d.cjs",
-      "default": "./dist/webpack/index.cjs"
+    "./next": {
+      "types": "./dist/next/index.d.cts",
+      "default": "./dist/next/index.cjs"
+    },
+    "./next/loader": {
+      "types": "./dist/next/loader.d.cts",
+      "default": "./dist/next/loader.cjs"
     }
   },
   "publishConfig": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -29,6 +29,14 @@
     ".": {
       "types": "./dist/index.d.cjs",
       "default": "./dist/index.cjs"
+    },
+    "./metro": {
+      "types": "./dist/metro/index.d.cjs",
+      "default": "./dist/metro/index.cjs"
+    },
+    "./webpack": {
+      "types": "./dist/webpack/index.d.cjs",
+      "default": "./dist/webpack/index.cjs"
     }
   },
   "publishConfig": {

--- a/packages/plugin-babel/src/catalogue.ts
+++ b/packages/plugin-babel/src/catalogue.ts
@@ -1,0 +1,32 @@
+import { readFile } from 'node:fs/promises';
+import { relative } from 'node:path';
+import type { Config } from '@saykit/config';
+import {
+  assembleCatalogueRecord,
+  resolveCatalogueSources,
+} from '@saykit/config/features/catalogue';
+
+/** Normalise an absolute path into the form bucket globs are written against. */
+const toId = (path: string) => relative(process.cwd(), path).replaceAll('\\', '/').split('?')[0]!;
+
+/**
+ * Assemble the catalogue at `path` into a `{ id: string }` record, merging the
+ * fallback chain (configured fallbacks + the source locale) so an untranslated
+ * key resolves to a fallback string.
+ *
+ * Returns `undefined` when the path is not a catalogue, and otherwise reports
+ * the files that fed the record alongside it — a bundler that can track them
+ * gets invalidation for free when a fallback locale is edited.
+ */
+export async function loadCatalogue(config: Config, path: string) {
+  const id = toId(path);
+  const bucket = config.buckets.find((b) => b.output.match(id));
+  if (!bucket) return;
+
+  const { sources } = resolveCatalogueSources(config, bucket, id);
+  const contents = await Promise.all(
+    sources.map((source) => readFile(source, 'utf8').catch(() => '')),
+  );
+
+  return { record: assembleCatalogueRecord(bucket, contents), sources };
+}

--- a/packages/plugin-babel/src/catalogue.ts
+++ b/packages/plugin-babel/src/catalogue.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
 import { relative } from 'node:path';
-import type { Config } from '@saykit/config';
+import type { Bucket, Config } from '@saykit/config';
 import {
   assembleCatalogueRecord,
   resolveCatalogueSources,
@@ -11,42 +10,43 @@ import {
 const toId = (path: string) => relative(process.cwd(), path).replaceAll('\\', '/').split('?')[0]!;
 
 /**
- * Match `path` against the buckets and resolve the fallback chain feeding it
- * (configured fallbacks + the source locale), so an untranslated key resolves
- * to a fallback string rather than going missing.
+ * The glob a bucket's catalogues match, e.g. `src/locales/*.po` — the `output`
+ * template with its placeholders filled in. Bundlers that select files by glob
+ * rather than by predicate need this to target exactly the catalogues, and
+ * nothing else sharing their extension.
  */
-function resolveCatalogue(config: Config, path: string) {
-  const id = toId(path);
-  const bucket = config.buckets.find((b) => b.output.match(id));
-  if (!bucket) return;
+export const catalogueGlob = (bucket: Bucket) =>
+  String(bucket.output)
+    .replace('{locale}', '*')
+    .replace('{extension}', bucket.formatter.extension.slice(1))
+    // Globs are matched against posix-separated paths on every platform.
+    .replaceAll('\\', '/')
+    .replace(/^\.\//, '');
 
-  return { bucket, sources: resolveCatalogueSources(config, bucket, id).sources };
-}
+/** Whether `path` is one of the config's catalogue outputs. */
+export const isCatalogue = (config: Config, path: string) =>
+  config.buckets.some((bucket) => bucket.output.match(toId(path)));
 
 /**
- * Assemble the catalogue at `path` into a `{ id: string }` record.
+ * Assemble the catalogue at `path` into a `{ id: string }` record, merging in
+ * the fallback chain (configured fallbacks + the source locale) so an
+ * untranslated key resolves to a fallback string rather than going missing.
  *
  * Returns `undefined` when the path is not a catalogue, and otherwise reports
  * the files that fed the record alongside it — a bundler that can track them
  * gets invalidation for free when a fallback locale is edited.
+ *
+ * Reads are synchronous so every caller can share one implementation: Babel's
+ * visitor cannot await, and the handful of files in a fallback chain are not
+ * worth an async path in a bundler that is blocked on the result anyway.
  */
-export async function loadCatalogue(config: Config, path: string) {
-  const found = resolveCatalogue(config, path);
-  if (!found) return;
+export function loadCatalogue(config: Config, path: string) {
+  const id = toId(path);
+  const bucket = config.buckets.find((b) => b.output.match(id));
+  if (!bucket) return;
 
-  const contents = await Promise.all(
-    found.sources.map((source) => readFile(source, 'utf8').catch(() => '')),
-  );
-
-  return { record: assembleCatalogueRecord(found.bucket, contents), sources: found.sources };
-}
-
-/** {@link loadCatalogue} for callers that cannot await — Babel visitors. */
-export function loadCatalogueSync(config: Config, path: string) {
-  const found = resolveCatalogue(config, path);
-  if (!found) return;
-
-  const contents = found.sources.map((source) => {
+  const { sources } = resolveCatalogueSources(config, bucket, id);
+  const contents = sources.map((source) => {
     try {
       return readFileSync(source, 'utf8');
     } catch {
@@ -54,5 +54,5 @@ export function loadCatalogueSync(config: Config, path: string) {
     }
   });
 
-  return { record: assembleCatalogueRecord(found.bucket, contents), sources: found.sources };
+  return { record: assembleCatalogueRecord(bucket, contents), sources };
 }

--- a/packages/plugin-babel/src/catalogue.ts
+++ b/packages/plugin-babel/src/catalogue.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { relative } from 'node:path';
 import type { Config } from '@saykit/config';
@@ -10,23 +11,48 @@ import {
 const toId = (path: string) => relative(process.cwd(), path).replaceAll('\\', '/').split('?')[0]!;
 
 /**
- * Assemble the catalogue at `path` into a `{ id: string }` record, merging the
- * fallback chain (configured fallbacks + the source locale) so an untranslated
- * key resolves to a fallback string.
+ * Match `path` against the buckets and resolve the fallback chain feeding it
+ * (configured fallbacks + the source locale), so an untranslated key resolves
+ * to a fallback string rather than going missing.
+ */
+function resolveCatalogue(config: Config, path: string) {
+  const id = toId(path);
+  const bucket = config.buckets.find((b) => b.output.match(id));
+  if (!bucket) return;
+
+  return { bucket, sources: resolveCatalogueSources(config, bucket, id).sources };
+}
+
+/**
+ * Assemble the catalogue at `path` into a `{ id: string }` record.
  *
  * Returns `undefined` when the path is not a catalogue, and otherwise reports
  * the files that fed the record alongside it — a bundler that can track them
  * gets invalidation for free when a fallback locale is edited.
  */
 export async function loadCatalogue(config: Config, path: string) {
-  const id = toId(path);
-  const bucket = config.buckets.find((b) => b.output.match(id));
-  if (!bucket) return;
+  const found = resolveCatalogue(config, path);
+  if (!found) return;
 
-  const { sources } = resolveCatalogueSources(config, bucket, id);
   const contents = await Promise.all(
-    sources.map((source) => readFile(source, 'utf8').catch(() => '')),
+    found.sources.map((source) => readFile(source, 'utf8').catch(() => '')),
   );
 
-  return { record: assembleCatalogueRecord(bucket, contents), sources };
+  return { record: assembleCatalogueRecord(found.bucket, contents), sources: found.sources };
+}
+
+/** {@link loadCatalogue} for callers that cannot await — Babel visitors. */
+export function loadCatalogueSync(config: Config, path: string) {
+  const found = resolveCatalogue(config, path);
+  if (!found) return;
+
+  const contents = found.sources.map((source) => {
+    try {
+      return readFileSync(source, 'utf8');
+    } catch {
+      return '';
+    }
+  });
+
+  return { record: assembleCatalogueRecord(found.bucket, contents), sources: found.sources };
 }

--- a/packages/plugin-babel/src/index.test.ts
+++ b/packages/plugin-babel/src/index.test.ts
@@ -29,6 +29,7 @@ vi.mock('@saykit/config/features/loader', () => ({ resolveConfig: () => config }
 
 const { default: plugin } = await import('./index.js');
 const { loadCatalogue } = await import('./catalogue.js');
+const { withSayKit } = await import('./next/index.js');
 
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
@@ -86,7 +87,7 @@ describe('plugin-babel catalogue imports', () => {
 });
 
 describe('loadCatalogue', () => {
-  it('assembles a catalogue into a record', async () => {
+  it('assembles a catalogue into a record', () => {
     writeFileSync(
       join(dir, 'en.json'),
       JSON.stringify([
@@ -95,30 +96,73 @@ describe('loadCatalogue', () => {
       ]),
     );
 
-    const catalogue = await loadCatalogue(config as never, join(dir, 'en.json'));
+    const catalogue = loadCatalogue(config as never, join(dir, 'en.json'));
     expect(catalogue?.record).toMatchObject({ greeting: 'Hello', farewell: 'Bye' });
   });
 
-  it('falls back to the source locale for keys untranslated in another locale', async () => {
+  it('falls back to the source locale for keys untranslated in another locale', () => {
     writeFileSync(
       join(dir, 'fr.json'),
       JSON.stringify([{ message: 'Hello', translation: 'Bonjour', id: 'greeting' }]),
     );
 
-    const catalogue = await loadCatalogue(config as never, join(dir, 'fr.json'));
+    const catalogue = loadCatalogue(config as never, join(dir, 'fr.json'));
     expect(catalogue?.record).toMatchObject({ greeting: 'Bonjour', farewell: 'Bye' });
     // Every file in the chain is reported so callers can register it for
     // invalidation, not just the locale's own file.
     expect(catalogue?.sources).toHaveLength(2);
   });
 
-  it('hashes a key when the message carries no id', async () => {
+  it('hashes a key when the message carries no id', () => {
     writeFileSync(join(dir, 'm2.json'), JSON.stringify([{ message: 'Bye' }]));
-    const catalogue = await loadCatalogue(config as never, join(dir, 'm2.json'));
+    const catalogue = loadCatalogue(config as never, join(dir, 'm2.json'));
     expect(catalogue?.record).toHaveProperty(generateHash('Bye', undefined));
   });
 
-  it('ignores a path that is not a catalogue', async () => {
-    expect(await loadCatalogue(config as never, join(dir, 'helper.ts'))).toBeUndefined();
+  it('ignores a path that is not a catalogue', () => {
+    expect(loadCatalogue(config as never, join(dir, 'helper.ts'))).toBeUndefined();
+  });
+});
+
+describe('next withSayKit', () => {
+  it('derives a Turbopack rule from the bucket output', () => {
+    const out = withSayKit({});
+    const [glob, rule] = Object.entries(out.turbopack.rules!)[0]!;
+
+    // The glob is the bucket's own output template, so nothing else sharing the
+    // extension is routed through the loader.
+    expect(glob.endsWith('/*.json')).toBe(true);
+    expect(rule).toMatchObject({ loaders: ['babel-plugin-saykit/next/loader'], as: '*.js' });
+  });
+
+  it('adds a webpack rule that matches catalogues and nothing else', () => {
+    const webpackConfig = { module: { rules: [] as unknown[] } };
+    withSayKit({}).webpack(webpackConfig, {});
+
+    const rule = webpackConfig.module.rules[0] as {
+      test: (path: string) => boolean;
+      type: string;
+    };
+    expect(rule.test(join(dir, 'fr.json'))).toBe(true);
+    expect(rule.test(join(dir, 'helper.ts'))).toBe(false);
+    // The loader emits JavaScript, so a `.json` catalogue must not be handed to
+    // webpack's JSON parser.
+    expect(rule.type).toBe('javascript/auto');
+  });
+
+  it('preserves the caller’s own turbopack rules and webpack function', () => {
+    const out = withSayKit({
+      turbopack: { rules: { '*.svg': { loaders: ['svg'] } } },
+      webpack: (c) => {
+        (c.module ??= {}).rules = ['mine'];
+        return c;
+      },
+    });
+
+    expect(out.turbopack.rules).toHaveProperty('*.svg');
+
+    const result = out.webpack({}, {});
+    expect(result.module!.rules![0]).toBe('mine');
+    expect(result.module!.rules).toHaveLength(2);
   });
 });

--- a/packages/plugin-babel/src/index.test.ts
+++ b/packages/plugin-babel/src/index.test.ts
@@ -32,8 +32,13 @@ const { loadCatalogue } = await import('./catalogue.js');
 
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
-const run = (code: string, filename: string) =>
-  transformSync(code, { filename, plugins: [plugin], babelrc: false, configFile: false })!.code!;
+const run = (code: string, filename: string, options: { catalogues?: 'inline' | 'module' } = {}) =>
+  transformSync(code, {
+    filename,
+    plugins: [[plugin, options]],
+    babelrc: false,
+    configFile: false,
+  })!.code!;
 
 describe('plugin-babel parserOverride', () => {
   it('runs the bucket transformer over matching source files', () => {
@@ -50,15 +55,33 @@ describe('plugin-babel parserOverride', () => {
     const out = run('const x = "MARK";', join(dir, 'app.js'));
     expect(out).toContain('MARK');
   });
+});
 
-  // Catalogues are assembled by the bundler's own module pipeline (see
-  // `loader.ts` / `metro-transformer.ts`), so the plugin must leave the import
-  // alone — inlining it would strip the dependency edge the bundler invalidates
-  // on. https://github.com/k0d13/saykit/issues/71
-  it('leaves catalogue imports intact', () => {
+describe('plugin-babel catalogue imports', () => {
+  const source = `import m from './messages.json';\nexport default m;`;
+
+  it('inlines the assembled record by default, so Babel alone is enough', () => {
     writeFileSync(join(dir, 'messages.json'), JSON.stringify([{ message: 'Hello' }]));
-    const out = run(`import m from './messages.json';\nexport default m;`, join(dir, 'app.ts'));
+    const out = run(source, join(dir, 'app.ts'));
+    expect(out).not.toContain('./messages.json');
+    expect(out).toContain('Hello');
+  });
+
+  // With a bundler integration wired up (see `webpack/index.ts` and
+  // `metro/transformer.ts`) the import has to survive — inlining it strips the
+  // dependency edge the bundler invalidates on, which is what broke hot reload
+  // in https://github.com/k0d13/saykit/issues/71.
+  it('leaves the import intact under `catalogues: "module"`', () => {
+    writeFileSync(join(dir, 'messages.json'), JSON.stringify([{ message: 'Hello' }]));
+    const out = run(source, join(dir, 'app.ts'), { catalogues: 'module' });
     expect(out).toContain('./messages.json');
+  });
+
+  it('requires a default import when inlining', () => {
+    writeFileSync(join(dir, 'messages.json'), JSON.stringify([{ message: 'Hello' }]));
+    expect(() => run(`import { m } from './messages.json';`, join(dir, 'app.ts'))).toThrow(
+      'require a default import',
+    );
   });
 });
 

--- a/packages/plugin-babel/src/index.test.ts
+++ b/packages/plugin-babel/src/index.test.ts
@@ -68,7 +68,7 @@ describe('plugin-babel catalogue imports', () => {
     expect(out).toContain('Hello');
   });
 
-  // With a bundler integration wired up (see `webpack/index.ts` and
+  // With a bundler integration wired up (see `next/loader.ts` and
   // `metro/transformer.ts`) the import has to survive — inlining it strips the
   // dependency edge the bundler invalidates on, which is what broke hot reload
   // in https://github.com/k0d13/saykit/issues/71.
@@ -81,7 +81,16 @@ describe('plugin-babel catalogue imports', () => {
   it('requires a default import when inlining', () => {
     writeFileSync(join(dir, 'messages.json'), JSON.stringify([{ message: 'Hello' }]));
     expect(() => run(`import { m } from './messages.json';`, join(dir, 'app.ts'))).toThrow(
-      'require a default import',
+      'require a single default import',
+    );
+  });
+
+  // Inlining replaces the whole declaration with one binding, so a named
+  // specifier alongside the default has to be rejected rather than dropped.
+  it('rejects a default import mixed with named specifiers', () => {
+    writeFileSync(join(dir, 'messages.json'), JSON.stringify([{ message: 'Hello' }]));
+    expect(() => run(`import m, { extra } from './messages.json';`, join(dir, 'app.ts'))).toThrow(
+      'require a single default import',
     );
   });
 });

--- a/packages/plugin-babel/src/index.test.ts
+++ b/packages/plugin-babel/src/index.test.ts
@@ -28,6 +28,7 @@ const config = {
 vi.mock('@saykit/config/features/loader', () => ({ resolveConfig: () => config }));
 
 const { default: plugin } = await import('./index.js');
+const { loadCatalogue } = await import('./catalogue.js');
 
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
@@ -49,65 +50,52 @@ describe('plugin-babel parserOverride', () => {
     const out = run('const x = "MARK";', join(dir, 'app.js'));
     expect(out).toContain('MARK');
   });
+
+  // Catalogues are assembled by the bundler's own module pipeline (see
+  // `loader.ts` / `metro-transformer.ts`), so the plugin must leave the import
+  // alone — inlining it would strip the dependency edge the bundler invalidates
+  // on. https://github.com/k0d13/saykit/issues/71
+  it('leaves catalogue imports intact', () => {
+    writeFileSync(join(dir, 'messages.json'), JSON.stringify([{ message: 'Hello' }]));
+    const out = run(`import m from './messages.json';\nexport default m;`, join(dir, 'app.ts'));
+    expect(out).toContain('./messages.json');
+  });
 });
 
-describe('plugin-babel inline imports', () => {
-  it('replaces a default import of a catalogue with an inlined record', () => {
-    writeFileSync(
-      join(dir, 'messages.json'),
-      JSON.stringify([
-        { message: 'Hello', translation: 'Bonjour', id: 'greeting' },
-        { message: 'Bye', translation: '' },
-      ]),
-    );
-    const out = run(`import m from './messages.json';\nexport default m;`, join(dir, 'app.ts'));
-    expect(out).toContain('greeting');
-    expect(out).toContain('Bonjour');
-    // No id + empty translation -> hashed key with the source text.
-    expect(out).toContain(generateHash('Bye', undefined));
-  });
-
-  it('falls back to the source locale for keys untranslated in a non-source locale', () => {
+describe('loadCatalogue', () => {
+  it('assembles a catalogue into a record', async () => {
     writeFileSync(
       join(dir, 'en.json'),
       JSON.stringify([
-        { message: 'Hello', id: 'greeting' },
-        { message: 'Bye', id: 'farewell' },
+        { message: 'Hello', translation: 'Hello', id: 'greeting' },
+        { message: 'Bye', translation: 'Bye', id: 'farewell' },
       ]),
     );
+
+    const catalogue = await loadCatalogue(config as never, join(dir, 'en.json'));
+    expect(catalogue?.record).toMatchObject({ greeting: 'Hello', farewell: 'Bye' });
+  });
+
+  it('falls back to the source locale for keys untranslated in another locale', async () => {
     writeFileSync(
       join(dir, 'fr.json'),
       JSON.stringify([{ message: 'Hello', translation: 'Bonjour', id: 'greeting' }]),
     );
 
-    const out = run(`import m from './fr.json';\nexport default m;`, join(dir, 'app.ts'));
-    expect(out).toContain('Bonjour'); // real translation
-    expect(out).toContain('Bye'); // untranslated -> source fallback
+    const catalogue = await loadCatalogue(config as never, join(dir, 'fr.json'));
+    expect(catalogue?.record).toMatchObject({ greeting: 'Bonjour', farewell: 'Bye' });
+    // Every file in the chain is reported so callers can register it for
+    // invalidation, not just the locale's own file.
+    expect(catalogue?.sources).toHaveLength(2);
   });
 
-  it('ignores bare (non-relative) imports', () => {
-    const out = run(`import x from 'some-pkg';\nx;`, join(dir, 'app.ts'));
-    expect(out).toContain("'some-pkg'");
+  it('hashes a key when the message carries no id', async () => {
+    writeFileSync(join(dir, 'm2.json'), JSON.stringify([{ message: 'Bye' }]));
+    const catalogue = await loadCatalogue(config as never, join(dir, 'm2.json'));
+    expect(catalogue?.record).toHaveProperty(generateHash('Bye', undefined));
   });
 
-  it('ignores relative imports that are not bucket outputs', () => {
-    const out = run(`import x from './helper.ts';\nx;`, join(dir, 'app.ts'));
-    expect(out).toContain('./helper.ts');
-  });
-
-  it('ignores imports when the file has no name', () => {
-    const out = transformSync(`import x from './messages.json';\nx;`, {
-      plugins: [plugin],
-      babelrc: false,
-      configFile: false,
-    })!.code!;
-    expect(out).toContain('./messages.json');
-  });
-
-  it('throws for a non-default import of a catalogue', () => {
-    writeFileSync(join(dir, 'm2.json'), JSON.stringify([]));
-    expect(() => run(`import { x } from './m2.json';\nx;`, join(dir, 'app.ts'))).toThrow(
-      'SayKit inline imports require a default import',
-    );
+  it('ignores a path that is not a catalogue', async () => {
+    expect(await loadCatalogue(config as never, join(dir, 'helper.ts'))).toBeUndefined();
   });
 });

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,26 +1,24 @@
-import { readFileSync } from 'node:fs';
-import { dirname, relative, resolve } from 'node:path';
-import { types as t, type PluginObj, type PluginAPI, type parse as Parse } from '@babel/core';
-import {
-  assembleCatalogueRecord,
-  resolveCatalogueSources,
-} from '@saykit/config/features/catalogue';
+import { relative } from 'node:path';
+import type { PluginObj, parse as Parse } from '@babel/core';
 import { resolveConfig } from '@saykit/config/features/loader';
 
 declare module '@babel/core' {
-  interface PluginAPI {
-    addExternalDependency(ref: string): void;
-  }
   interface PluginObj {
     parserOverride(code: string, opts: TransformOptions, parse: typeof Parse): ParseResult | null;
   }
 }
 
-export default (api: PluginAPI): PluginObj => {
+export default (): PluginObj => {
   const config = resolveConfig();
 
   return {
     name: 'saykit',
+
+    // The macro rewrite happens in `parserOverride`, before the AST exists, so
+    // there is nothing left for a visitor to do. Catalogue imports are handled
+    // by the bundler's module pipeline — see `./loader.ts` and
+    // `./metro-transformer.ts`.
+    visitor: {},
 
     parserOverride(code, opts, parse) {
       const id_ = opts.sourceFileName;
@@ -31,57 +29,6 @@ export default (api: PluginAPI): PluginObj => {
       const transformed = bucket?.transformer.transform(code, id) ?? code;
 
       return parse(transformed, opts);
-    },
-
-    visitor: {
-      // TODO: This is fragile, it does not work with dynamic imports, document this
-      ImportDeclaration(path, state) {
-        const importee = path.node.source.value;
-        if (!importee.startsWith('.')) return;
-        const importer = state.filename ?? state.file.opts.filename;
-        if (!importer) return;
-        const id_ = resolve(dirname(importer), importee);
-
-        const id = relative(process.cwd(), id_).replaceAll('\\', '/').split('?')[0]!;
-        const bucket = config.buckets.find((b) => b.output.match(id));
-        if (!bucket) return;
-
-        const specifier = path.node.specifiers.find((s) => s.type === 'ImportDefaultSpecifier');
-        if (!specifier)
-          throw path.buildCodeFrameError('SayKit inline imports require a default import');
-
-        // Merge the fallback chain (configured fallbacks + the source locale)
-        // so untranslated keys resolve to a fallback string at build time.
-        const { sources } = resolveCatalogueSources(config, bucket, id);
-        const contents = sources.map((source) => {
-          try {
-            return readFileSync(source, 'utf8');
-          } catch {
-            return '';
-          }
-        });
-
-        for (const source of sources) {
-          try {
-            api.addExternalDependency(source);
-          } catch {}
-        }
-
-        const entries = Object.entries(assembleCatalogueRecord(bucket, contents));
-
-        path.replaceWith(
-          t.variableDeclaration('const', [
-            t.variableDeclarator(
-              t.identifier(specifier.local.name),
-              t.objectExpression(
-                entries.map(([key, value]) =>
-                  t.objectProperty(t.stringLiteral(key), t.stringLiteral(value)),
-                ),
-              ),
-            ),
-          ]),
-        );
-      },
     },
   };
 };

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -46,11 +46,13 @@ export default (_: unknown, { catalogues = 'inline' }: Options = {}): PluginObj 
               const catalogue = loadCatalogue(config, resolve(dirname(importer), importee));
               if (!catalogue) return;
 
-              const specifier = path.node.specifiers.find(
-                (s) => s.type === 'ImportDefaultSpecifier',
-              );
-              if (!specifier)
-                throw path.buildCodeFrameError('SayKit inline imports require a default import');
+              // The whole declaration is replaced by one binding, so anything
+              // bound alongside the default would be dropped silently.
+              const [specifier, ...rest] = path.node.specifiers;
+              if (specifier?.type !== 'ImportDefaultSpecifier' || rest.length > 0)
+                throw path.buildCodeFrameError(
+                  'SayKit inline imports require a single default import',
+                );
 
               path.replaceWith(
                 t.variableDeclaration('const', [

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,7 +1,7 @@
 import { dirname, relative, resolve } from 'node:path';
 import { types as t, type PluginObj, type parse as Parse } from '@babel/core';
 import { resolveConfig } from '@saykit/config/features/loader';
-import { loadCatalogueSync } from './catalogue.js';
+import { loadCatalogue } from './catalogue.js';
 
 declare module '@babel/core' {
   interface PluginObj {
@@ -19,7 +19,7 @@ export interface Options {
    * bytes change — editing a catalogue will not hot-reload.
    *
    * `'module'` leaves the import for a bundler integration to serve —
-   * `babel-plugin-saykit/webpack` or `babel-plugin-saykit/metro`. Set this
+   * `babel-plugin-saykit/next` or `babel-plugin-saykit/metro`. Set this
    * whenever one of those is wired up, or the import gets inlined before the
    * integration is ever asked for the module.
    */
@@ -43,7 +43,7 @@ export default (_: unknown, { catalogues = 'inline' }: Options = {}): PluginObj 
               const importer = state.filename ?? state.file.opts.filename;
               if (!importer) return;
 
-              const catalogue = loadCatalogueSync(config, resolve(dirname(importer), importee));
+              const catalogue = loadCatalogue(config, resolve(dirname(importer), importee));
               if (!catalogue) return;
 
               const specifier = path.node.specifiers.find(

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,6 +1,7 @@
-import { relative } from 'node:path';
-import type { PluginObj, parse as Parse } from '@babel/core';
+import { dirname, relative, resolve } from 'node:path';
+import { types as t, type PluginObj, type parse as Parse } from '@babel/core';
 import { resolveConfig } from '@saykit/config/features/loader';
+import { loadCatalogueSync } from './catalogue.js';
 
 declare module '@babel/core' {
   interface PluginObj {
@@ -8,17 +9,63 @@ declare module '@babel/core' {
   }
 }
 
-export default (): PluginObj => {
+export interface Options {
+  /**
+   * How a catalogue import is resolved.
+   *
+   * `'inline'` (the default) replaces the import with the assembled record, so
+   * the Babel plugin is enough on its own. The cost is that the record lands in
+   * the importing module, which a bundler only re-reads when that module's own
+   * bytes change — editing a catalogue will not hot-reload.
+   *
+   * `'module'` leaves the import for a bundler integration to serve —
+   * `babel-plugin-saykit/webpack` or `babel-plugin-saykit/metro`. Set this
+   * whenever one of those is wired up, or the import gets inlined before the
+   * integration is ever asked for the module.
+   */
+  catalogues?: 'inline' | 'module';
+}
+
+export default (_: unknown, { catalogues = 'inline' }: Options = {}): PluginObj => {
   const config = resolveConfig();
 
   return {
     name: 'saykit',
 
-    // The macro rewrite happens in `parserOverride`, before the AST exists, so
-    // there is nothing left for a visitor to do. Catalogue imports are handled
-    // by the bundler's module pipeline — see `./loader.ts` and
-    // `./metro-transformer.ts`.
-    visitor: {},
+    visitor:
+      catalogues === 'module'
+        ? {}
+        : {
+            // TODO: This is fragile, it does not work with dynamic imports, document this
+            ImportDeclaration(path, state) {
+              const importee = path.node.source.value;
+              if (!importee.startsWith('.')) return;
+              const importer = state.filename ?? state.file.opts.filename;
+              if (!importer) return;
+
+              const catalogue = loadCatalogueSync(config, resolve(dirname(importer), importee));
+              if (!catalogue) return;
+
+              const specifier = path.node.specifiers.find(
+                (s) => s.type === 'ImportDefaultSpecifier',
+              );
+              if (!specifier)
+                throw path.buildCodeFrameError('SayKit inline imports require a default import');
+
+              path.replaceWith(
+                t.variableDeclaration('const', [
+                  t.variableDeclarator(
+                    t.identifier(specifier.local.name),
+                    t.objectExpression(
+                      Object.entries(catalogue.record).map(([key, value]) =>
+                        t.objectProperty(t.stringLiteral(key), t.stringLiteral(value)),
+                      ),
+                    ),
+                  ),
+                ]),
+              );
+            },
+          },
 
     parserOverride(code, opts, parse) {
       const id_ = opts.sourceFileName;

--- a/packages/plugin-babel/src/metro/index.ts
+++ b/packages/plugin-babel/src/metro/index.ts
@@ -16,6 +16,8 @@ interface MetroConfig {
  * The base is the config's `projectRoot` — `process.cwd()` is wrong whenever
  * Metro is started from elsewhere, which in a monorepo is the normal case.
  */
+const transformerPath = join(__dirname, 'transformer.cjs');
+
 function resolveUpstream(specifier: string, projectRoot: string) {
   if (isAbsolute(specifier)) return specifier;
 
@@ -38,8 +40,15 @@ function resolveUpstream(specifier: string, projectRoot: string) {
  * Metro's transform cache is keyed on each file's own bytes, so a catalogue has
  * to stay a module of its own to be invalidated at all — see
  * `./transformer.ts`.
+ *
+ * Apply this outermost. Anything wrapped around it that also sets
+ * `transformerPath` replaces this one, and catalogues stop being assembled.
  */
 export function withSayKit<T extends MetroConfig>(metroConfig: T): T {
+  // Wrapping our own transformer would make it its own upstream, and every
+  // transform would recurse until the worker died.
+  if (metroConfig.transformerPath === transformerPath) return metroConfig;
+
   const config = resolveConfig();
 
   // Metro resolves `.json` itself but knows nothing of catalogue formats like
@@ -59,7 +68,7 @@ export function withSayKit<T extends MetroConfig>(metroConfig: T): T {
   return {
     ...metroConfig,
     resolver: { ...metroConfig.resolver, sourceExts },
-    transformerPath: join(__dirname, 'transformer.cjs'),
+    transformerPath,
     transformer: {
       ...metroConfig.transformer,
       saykitTransformerPath: resolveUpstream(upstream, metroConfig.projectRoot ?? process.cwd()),

--- a/packages/plugin-babel/src/metro/index.ts
+++ b/packages/plugin-babel/src/metro/index.ts
@@ -3,9 +3,28 @@ import { isAbsolute, join } from 'node:path';
 import { resolveConfig } from '@saykit/config/features/loader';
 
 interface MetroConfig {
+  projectRoot?: string;
   resolver?: { sourceExts?: string[] };
   transformer?: Record<string, unknown>;
   transformerPath?: string;
+}
+
+/**
+ * Resolve Metro's own transformer from the project rather than from this
+ * package, since it is the project that depends on Metro.
+ *
+ * The base is the config's `projectRoot` — `process.cwd()` is wrong whenever
+ * Metro is started from elsewhere, which in a monorepo is the normal case.
+ */
+function resolveUpstream(specifier: string, projectRoot: string) {
+  if (isAbsolute(specifier)) return specifier;
+
+  try {
+    return createRequire(join(projectRoot, 'metro.config.js')).resolve(specifier);
+  } catch {
+    // A hoisted install can still satisfy it from here.
+    return require.resolve(specifier);
+  }
 }
 
 /**
@@ -34,8 +53,7 @@ export function withSayKit<T extends MetroConfig>(metroConfig: T): T {
     if (!sourceExts.includes(extension)) sourceExts.push(extension);
 
   // Metro loads a worker standalone, so the wrapped transformer reaches its
-  // upstream through the transformer config rather than a closure. Resolve it
-  // from the project, since it is the project that depends on Metro.
+  // upstream through the transformer config rather than a closure.
   const upstream = metroConfig.transformerPath ?? 'metro-transform-worker';
 
   return {
@@ -44,9 +62,7 @@ export function withSayKit<T extends MetroConfig>(metroConfig: T): T {
     transformerPath: join(__dirname, 'transformer.cjs'),
     transformer: {
       ...metroConfig.transformer,
-      saykitTransformerPath: isAbsolute(upstream)
-        ? upstream
-        : createRequire(join(process.cwd(), 'metro.config.js')).resolve(upstream),
+      saykitTransformerPath: resolveUpstream(upstream, metroConfig.projectRoot ?? process.cwd()),
     },
   };
 }

--- a/packages/plugin-babel/src/metro/index.ts
+++ b/packages/plugin-babel/src/metro/index.ts
@@ -1,0 +1,52 @@
+import { createRequire } from 'node:module';
+import { isAbsolute, join } from 'node:path';
+import { resolveConfig } from '@saykit/config/features/loader';
+
+interface MetroConfig {
+  resolver?: { sourceExts?: string[] };
+  transformer?: Record<string, unknown>;
+  transformerPath?: string;
+}
+
+/**
+ * Wrap a Metro config so SayKit catalogues load as real modules.
+ *
+ * ```js
+ * const { withSayKit } = require('babel-plugin-saykit/metro');
+ * module.exports = withSayKit(getDefaultConfig(__dirname));
+ * ```
+ *
+ * Metro's transform cache is keyed on each file's own bytes, so a catalogue has
+ * to stay a module of its own to be invalidated at all — see
+ * `./transformer.ts`.
+ */
+export function withSayKit<T extends MetroConfig>(metroConfig: T): T {
+  const config = resolveConfig();
+
+  // Metro resolves `.json` itself but knows nothing of catalogue formats like
+  // `.po`, and a file it cannot resolve is not a module it can invalidate.
+  const extensions = config.buckets
+    .map((bucket) => bucket.formatter.extension.slice(1))
+    .filter((extension) => extension !== 'json');
+
+  const sourceExts = [...(metroConfig.resolver?.sourceExts ?? [])];
+  for (const extension of extensions)
+    if (!sourceExts.includes(extension)) sourceExts.push(extension);
+
+  // Metro loads a worker standalone, so the wrapped transformer reaches its
+  // upstream through the transformer config rather than a closure. Resolve it
+  // from the project, since it is the project that depends on Metro.
+  const upstream = metroConfig.transformerPath ?? 'metro-transform-worker';
+
+  return {
+    ...metroConfig,
+    resolver: { ...metroConfig.resolver, sourceExts },
+    transformerPath: join(__dirname, 'transformer.cjs'),
+    transformer: {
+      ...metroConfig.transformer,
+      saykitTransformerPath: isAbsolute(upstream)
+        ? upstream
+        : createRequire(join(process.cwd(), 'metro.config.js')).resolve(upstream),
+    },
+  };
+}

--- a/packages/plugin-babel/src/metro/transformer.ts
+++ b/packages/plugin-babel/src/metro/transformer.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { findConfigFile, resolveConfig } from '@saykit/config/features/loader';
+import { resolveConfig, resolveConfigFile } from '@saykit/config/features/loader';
 import { loadCatalogue } from '../catalogue.js';
 
 /**
@@ -29,14 +29,6 @@ const config = resolveConfig();
 const upstream = (transformerConfig: TransformerConfig): Worker =>
   require(transformerConfig.saykitTransformerPath) as Worker;
 
-const read = (path: string) => {
-  try {
-    return readFileSync(path, 'utf8');
-  } catch {
-    return '';
-  }
-};
-
 /**
  * What a catalogue transforms into depends on the SayKit config — the fallback
  * chain it resolves, the formatter that parses it — and on the version of this
@@ -45,8 +37,8 @@ const read = (path: string) => {
  * every catalogue serving the record it was cached with.
  */
 const salt = createHash('sha1')
-  .update(read(join(__dirname, '..', '..', 'package.json')))
-  .update(read(findConfigFile('saykit', process.cwd())?.id ?? ''))
+  .update(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'))
+  .update(readFileSync(resolveConfigFile(), 'utf8'))
   .digest('hex');
 
 /**
@@ -56,7 +48,7 @@ const salt = createHash('sha1')
  * catalogue's own source, leaving the file a real module whose sha1 — and
  * therefore Metro's transform cache entry — moves whenever it is edited.
  */
-export async function transform(
+export function transform(
   transformerConfig: TransformerConfig,
   projectRoot: string,
   filename: string,
@@ -64,7 +56,7 @@ export async function transform(
   options: unknown,
 ) {
   const worker = upstream(transformerConfig);
-  const catalogue = await loadCatalogue(config, filename);
+  const catalogue = loadCatalogue(config, filename);
   if (!catalogue) return worker.transform(transformerConfig, projectRoot, filename, data, options);
 
   // Metro reads a `.json` module as its body verbatim and everything else as

--- a/packages/plugin-babel/src/metro/transformer.ts
+++ b/packages/plugin-babel/src/metro/transformer.ts
@@ -1,4 +1,7 @@
-import { resolveConfig } from '@saykit/config/features/loader';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { findConfigFile, resolveConfig } from '@saykit/config/features/loader';
 import { loadCatalogue } from '../catalogue.js';
 
 /**
@@ -25,6 +28,26 @@ const config = resolveConfig();
 
 const upstream = (transformerConfig: TransformerConfig): Worker =>
   require(transformerConfig.saykitTransformerPath) as Worker;
+
+const read = (path: string) => {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return '';
+  }
+};
+
+/**
+ * What a catalogue transforms into depends on the SayKit config — the fallback
+ * chain it resolves, the formatter that parses it — and on the version of this
+ * package doing the assembling. Neither is a byte of the file Metro hashes, so
+ * without them in the cache key, editing `saykit.config.*` or upgrading leaves
+ * every catalogue serving the record it was cached with.
+ */
+const salt = createHash('sha1')
+  .update(read(join(__dirname, '..', '..', 'package.json')))
+  .update(read(findConfigFile('saykit', process.cwd())?.id ?? ''))
+  .digest('hex');
 
 /**
  * Metro reads `.json` straight through `transformJSON` and never runs Babel over
@@ -53,5 +76,5 @@ export async function transform(
 }
 
 export function getCacheKey(transformerConfig: TransformerConfig, options?: unknown) {
-  return upstream(transformerConfig).getCacheKey(transformerConfig, options);
+  return `${upstream(transformerConfig).getCacheKey(transformerConfig, options)}-saykit-${salt}`;
 }

--- a/packages/plugin-babel/src/metro/transformer.ts
+++ b/packages/plugin-babel/src/metro/transformer.ts
@@ -1,0 +1,57 @@
+import { resolveConfig } from '@saykit/config/features/loader';
+import { loadCatalogue } from '../catalogue.js';
+
+/**
+ * The transformer config Metro hands each worker call. `saykitTransformerPath`
+ * is the upstream worker this one wraps, stashed here by {@link withSayKit}
+ * because a worker is loaded standalone and has no other way to reach it.
+ */
+interface TransformerConfig {
+  saykitTransformerPath: string;
+}
+
+interface Worker {
+  transform(
+    config: TransformerConfig,
+    projectRoot: string,
+    filename: string,
+    data: Buffer,
+    options: unknown,
+  ): Promise<unknown>;
+  getCacheKey(config: TransformerConfig, options?: unknown): string;
+}
+
+const config = resolveConfig();
+
+const upstream = (transformerConfig: TransformerConfig): Worker =>
+  require(transformerConfig.saykitTransformerPath) as Worker;
+
+/**
+ * Metro reads `.json` straight through `transformJSON` and never runs Babel over
+ * it, so a Babel plugin cannot reach a catalogue at all. Wrapping the transform
+ * worker is the one place that can: it substitutes the assembled record for the
+ * catalogue's own source, leaving the file a real module whose sha1 — and
+ * therefore Metro's transform cache entry — moves whenever it is edited.
+ */
+export async function transform(
+  transformerConfig: TransformerConfig,
+  projectRoot: string,
+  filename: string,
+  data: Buffer,
+  options: unknown,
+) {
+  const worker = upstream(transformerConfig);
+  const catalogue = await loadCatalogue(config, filename);
+  if (!catalogue) return worker.transform(transformerConfig, projectRoot, filename, data, options);
+
+  // Metro reads a `.json` module as its body verbatim and everything else as
+  // JavaScript, so each needs the record in the shape it expects.
+  const record = JSON.stringify(catalogue.record);
+  const code = filename.endsWith('.json') ? record : `module.exports = ${record};`;
+
+  return worker.transform(transformerConfig, projectRoot, filename, Buffer.from(code), options);
+}
+
+export function getCacheKey(transformerConfig: TransformerConfig, options?: unknown) {
+  return upstream(transformerConfig).getCacheKey(transformerConfig, options);
+}

--- a/packages/plugin-babel/src/next/index.ts
+++ b/packages/plugin-babel/src/next/index.ts
@@ -1,0 +1,84 @@
+import { resolveConfig } from '@saykit/config/features/loader';
+import { catalogueGlob, isCatalogue } from '../catalogue.js';
+
+/**
+ * The slice of Next's config this touches. Typed here rather than imported so
+ * the package does not depend on `next`.
+ */
+interface NextConfig {
+  turbopack?: {
+    rules?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  webpack?: (config: WebpackConfig, context: unknown) => WebpackConfig;
+  [key: string]: unknown;
+}
+
+interface WebpackConfig {
+  module?: { rules?: unknown[] };
+  [key: string]: unknown;
+}
+
+// Turbopack resolves loaders by module specifier, so this has to be a published
+// export even though it is not a supported entry point on its own.
+const loader = 'babel-plugin-saykit/next/loader';
+
+/**
+ * Wrap a Next config so SayKit catalogues load as real modules.
+ *
+ * ```js
+ * import { withSayKit } from 'babel-plugin-saykit/next';
+ * export default withSayKit({});
+ * ```
+ *
+ * Pair it with `catalogues: 'module'` on the Babel plugin — the plugin has to
+ * leave the import alone for the loader to ever be asked for the module.
+ *
+ * Rules are derived from the SayKit config, so both bundlers get one per bucket
+ * targeting exactly that bucket's `output` — nothing else sharing the extension
+ * goes through the loader, which matters most for a `.json` bucket, where the
+ * alternative would be routing every JSON import in the app through it.
+ */
+export function withSayKit<T extends NextConfig>(
+  nextConfig: T = {} as T,
+): T & Required<Pick<NextConfig, 'turbopack' | 'webpack'>> {
+  const config = resolveConfig();
+
+  // Turbopack selects by glob and has no predicate form, so the bucket's output
+  // template is filled in and matched wherever it sits under the project root.
+  // `as: '*.js'` because the loader emits JavaScript for every extension.
+  const rules = Object.fromEntries(
+    config.buckets.map((bucket) => [
+      `**/${catalogueGlob(bucket)}`,
+      { loaders: [loader], as: '*.js' },
+    ]),
+  );
+
+  return {
+    ...nextConfig,
+
+    turbopack: {
+      ...nextConfig.turbopack,
+      rules: { ...nextConfig.turbopack?.rules, ...rules },
+    },
+
+    // Turbopack is the default, but `next --webpack` needs the same wiring.
+    webpack: (webpackConfig: WebpackConfig, context: unknown) => {
+      const result = nextConfig.webpack?.(webpackConfig, context) ?? webpackConfig;
+
+      result.module ??= {};
+      result.module.rules ??= [];
+      result.module.rules.push({
+        // A predicate, so the rule covers exactly the catalogues however the
+        // buckets are laid out.
+        test: (path: string) => isCatalogue(config, path),
+        use: loader,
+        // The loader emits JavaScript, which webpack would not assume for a
+        // `.json` catalogue — it would hand the output to its JSON parser.
+        type: 'javascript/auto',
+      });
+
+      return result;
+    },
+  };
+}

--- a/packages/plugin-babel/src/next/loader.ts
+++ b/packages/plugin-babel/src/next/loader.ts
@@ -8,15 +8,19 @@ import { loadCatalogue } from '../catalogue.js';
  */
 interface LoaderContext {
   resourcePath: string;
-  async(): (error: unknown, content?: string) => void;
   addDependency(file: string): void;
 }
 
 const config = resolveConfig();
 
 /**
- * Webpack/Turbopack loader that replaces a catalogue file with its assembled
- * record.
+ * Replaces a catalogue file with its assembled record.
+ *
+ * This is a *loader* rather than a plugin because Turbopack runs loaders and
+ * not webpack plugins, and it is published only so `withSayKit` can name it in
+ * the rules it generates. A plain webpack, Vite or Rollup build should reach for
+ * `unplugin-saykit` instead, which does the same job through each bundler's own
+ * plugin API.
  *
  * The catalogue stays a real module, which is the whole point: the importer
  * keeps a dependency edge to it, so editing a catalogue invalidates exactly the
@@ -24,14 +28,13 @@ const config = resolveConfig();
  * importer's own bytes unchanged, and no bundler can invalidate on that.
  */
 export default function saykitLoader(this: LoaderContext, source: string) {
-  const callback = this.async();
+  const catalogue = loadCatalogue(config, this.resourcePath);
+  if (!catalogue) return source;
 
-  loadCatalogue(config, this.resourcePath).then((catalogue) => {
-    if (!catalogue) return callback(null, source);
+  // Fallback files feed this module, so editing them must invalidate it too.
+  for (const file of catalogue.sources) this.addDependency(file);
 
-    // Fallback files feed this module, so editing them must invalidate it too.
-    for (const file of catalogue.sources) this.addDependency(file);
-
-    callback(null, `export default ${JSON.stringify(catalogue.record)}`);
-  }, callback);
+  // Always JavaScript, whatever the catalogue's extension — which is why the
+  // generated rules carry `type: 'javascript/auto'` and `as: '*.js'`.
+  return `export default ${JSON.stringify(catalogue.record)}`;
 }

--- a/packages/plugin-babel/src/webpack/index.ts
+++ b/packages/plugin-babel/src/webpack/index.ts
@@ -1,0 +1,37 @@
+import { resolveConfig } from '@saykit/config/features/loader';
+import { loadCatalogue } from '../catalogue.js';
+
+/**
+ * The slice of webpack's loader context this needs. Typing it here rather than
+ * depending on `webpack` keeps the package free of a bundler dependency, and
+ * Turbopack implements the same surface for the loaders it runs.
+ */
+interface LoaderContext {
+  resourcePath: string;
+  async(): (error: unknown, content?: string) => void;
+  addDependency(file: string): void;
+}
+
+const config = resolveConfig();
+
+/**
+ * Webpack/Turbopack loader that replaces a catalogue file with its assembled
+ * record.
+ *
+ * The catalogue stays a real module, which is the whole point: the importer
+ * keeps a dependency edge to it, so editing a catalogue invalidates exactly the
+ * modules that read it. Inlining the record into the importer instead leaves the
+ * importer's own bytes unchanged, and no bundler can invalidate on that.
+ */
+export default function saykitLoader(this: LoaderContext, source: string) {
+  const callback = this.async();
+
+  loadCatalogue(config, this.resourcePath).then((catalogue) => {
+    if (!catalogue) return callback(null, source);
+
+    // Fallback files feed this module, so editing them must invalidate it too.
+    for (const file of catalogue.sources) this.addDependency(file);
+
+    callback(null, `export default ${JSON.stringify(catalogue.record)}`);
+  }, callback);
+}

--- a/packages/plugin-babel/tsdown.config.ts
+++ b/packages/plugin-babel/tsdown.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/metro/index.ts', 'src/metro/transformer.ts', 'src/webpack/index.ts'],
   format: 'cjs',
 });

--- a/packages/plugin-babel/tsdown.config.ts
+++ b/packages/plugin-babel/tsdown.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/metro/index.ts', 'src/metro/transformer.ts', 'src/webpack/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/metro/index.ts',
+    'src/metro/transformer.ts',
+    'src/next/index.ts',
+    'src/next/loader.ts',
+  ],
   format: 'cjs',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,40 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  examples/babel:
+    dependencies:
+      saykit:
+        specifier: workspace:^
+        version: link:../../packages/integration
+    devDependencies:
+      '@babel/cli':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7(supports-color@10.2.2)
+      '@babel/preset-env':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/preset-typescript':
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@saykit/config':
+        specifier: workspace:^
+        version: link:../../packages/config
+      '@saykit/format-po':
+        specifier: workspace:^
+        version: link:../../packages/format-po
+      '@saykit/transform-js':
+        specifier: workspace:^
+        version: link:../../packages/transform-js
+      babel-plugin-saykit:
+        specifier: workspace:^
+        version: link:../../packages/plugin-babel
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   examples/browser-extension:
     dependencies:
       saykit:
@@ -660,6 +694,13 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
+  '@babel/cli@7.29.7':
+    resolution: {integrity: sha512-/75HwRbAYPqXv/Ax1h7Fg3IZfXgdU98jnA8H93/m/QBaPV3Hp5ICoLqzGYye1yHBCgpmXvtqgSUN8oOKX5tojQ==}
+    engines: {node: '>=6.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
@@ -690,6 +731,10 @@ packages:
 
   '@babel/generator@7.29.7':
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@8.0.0':
@@ -812,10 +857,51 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@8.0.4':
     resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7':
+    resolution: {integrity: sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7':
+    resolution: {integrity: sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7':
+    resolution: {integrity: sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7':
+    resolution: {integrity: sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7':
+    resolution: {integrity: sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.13.0
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7':
+    resolution: {integrity: sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/plugin-proposal-decorators@7.29.7':
     resolution: {integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==}
@@ -825,6 +911,12 @@ packages:
 
   '@babel/plugin-proposal-export-default-from@7.29.7':
     resolution: {integrity: sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
+    resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -852,6 +944,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-syntax-import-assertions@7.29.7':
+    resolution: {integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.29.7':
+    resolution: {integrity: sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-syntax-jsx@7.29.7':
     resolution: {integrity: sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==}
     engines: {node: '>=6.9.0'}
@@ -874,6 +978,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
+    resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-transform-arrow-functions@7.29.7':
+    resolution: {integrity: sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-async-generator-functions@7.29.7':
     resolution: {integrity: sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==}
     engines: {node: '>=6.9.0'}
@@ -882,6 +998,12 @@ packages:
 
   '@babel/plugin-transform-async-to-generator@7.29.7':
     resolution: {integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-block-scoped-functions@7.29.7':
+    resolution: {integrity: sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -910,8 +1032,50 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-computed-properties@7.29.7':
+    resolution: {integrity: sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-destructuring@7.29.7':
     resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-dotall-regex@7.29.7':
+    resolution: {integrity: sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-duplicate-keys@7.29.7':
+    resolution: {integrity: sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7':
+    resolution: {integrity: sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-transform-dynamic-import@7.29.7':
+    resolution: {integrity: sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-explicit-resource-management@7.29.7':
+    resolution: {integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-exponentiation-operator@7.29.7':
+    resolution: {integrity: sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -934,8 +1098,38 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-function-name@7.29.7':
+    resolution: {integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-json-strings@7.29.7':
+    resolution: {integrity: sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-literals@7.29.7':
+    resolution: {integrity: sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-logical-assignment-operators@7.29.7':
     resolution: {integrity: sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-member-expression-literals@7.29.7':
+    resolution: {integrity: sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-amd@7.29.7':
+    resolution: {integrity: sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -946,11 +1140,29 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-modules-systemjs@7.29.8':
+    resolution: {integrity: sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-umd@7.29.7':
+    resolution: {integrity: sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7':
     resolution: {integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/plugin-transform-new-target@7.29.7':
+    resolution: {integrity: sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
     resolution: {integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==}
@@ -958,8 +1170,20 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-numeric-separator@7.29.7':
+    resolution: {integrity: sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-object-rest-spread@7.29.7':
     resolution: {integrity: sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-object-super@7.29.7':
+    resolution: {integrity: sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -994,6 +1218,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-property-literals@7.29.7':
+    resolution: {integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-display-name@7.29.7':
     resolution: {integrity: sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==}
     engines: {node: '>=6.9.0'}
@@ -1018,8 +1248,56 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-regenerator@7.29.8':
+    resolution: {integrity: sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-regexp-modifiers@7.29.7':
+    resolution: {integrity: sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-transform-reserved-words@7.29.7':
+    resolution: {integrity: sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-runtime@7.29.7':
     resolution: {integrity: sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-shorthand-properties@7.29.7':
+    resolution: {integrity: sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-spread@7.29.8':
+    resolution: {integrity: sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-sticky-regex@7.29.7':
+    resolution: {integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-template-literals@7.29.7':
+    resolution: {integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typeof-symbol@7.29.7':
+    resolution: {integrity: sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1030,11 +1308,40 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-unicode-escapes@7.29.7':
+    resolution: {integrity: sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-unicode-property-regex@7.29.7':
+    resolution: {integrity: sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-unicode-regex@7.29.7':
     resolution: {integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-unicode-sets-regex@7.29.7':
+    resolution: {integrity: sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/preset-env@7.29.7':
+    resolution: {integrity: sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-modules@0.1.6-no-external-plugins':
+    resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
 
   '@babel/preset-typescript@7.29.7':
     resolution: {integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==}
@@ -1058,12 +1365,20 @@ packages:
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@8.0.4':
     resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.4':
@@ -2327,6 +2642,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
+    resolution: {integrity: sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4309,6 +4627,10 @@ packages:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
     engines: {node: '>=14'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
@@ -4356,6 +4678,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  babel-plugin-polyfill-corejs3@0.14.2:
+    resolution: {integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
   babel-plugin-polyfill-regenerator@0.6.8:
     resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
     peerDependencies:
@@ -4394,6 +4721,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -4420,6 +4750,10 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
@@ -4433,6 +4767,9 @@ packages:
   bplist-parser@0.3.2:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -4500,6 +4837,10 @@ packages:
 
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -4582,6 +4923,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -4600,6 +4945,9 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
@@ -5027,6 +5375,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -5216,6 +5568,12 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fs-readdir-recursive@1.1.0:
+    resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5388,6 +5746,10 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
@@ -5529,6 +5891,10 @@ packages:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -5550,6 +5916,10 @@ packages:
 
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
@@ -5971,6 +6341,10 @@ packages:
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
+  make-dir@2.1.0:
+    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
+    engines: {node: '>=6'}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -6262,6 +6636,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6383,6 +6760,10 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -6409,6 +6790,9 @@ packages:
   on-headers@1.1.0:
     resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@2.0.1:
     resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
@@ -6509,6 +6893,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -6733,6 +7121,10 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
@@ -6908,6 +7300,10 @@ packages:
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -6984,6 +7380,10 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slash@2.0.0:
+    resolution: {integrity: sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==}
+    engines: {node: '>=6'}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -7627,6 +8027,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@7.5.13:
     resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
     engines: {node: '>=8.3.0'}
@@ -7775,6 +8178,20 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@babel/cli@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@jridgewell/trace-mapping': 0.3.31
+      commander: 6.2.1
+      convert-source-map: 2.0.0
+      fs-readdir-recursive: 1.1.0
+      glob: 7.2.3
+      make-dir: 2.1.0
+      slash: 2.0.0
+    optionalDependencies:
+      '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents.3
+      chokidar: 3.6.0
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -7842,6 +8259,14 @@ snapshots:
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -8005,10 +8430,57 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/parser@8.0.4':
     dependencies:
       '@babel/types': 8.0.4
     optional: true
+
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
@@ -8023,6 +8495,10 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
@@ -8040,6 +8516,16 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -8064,6 +8550,17 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -8081,6 +8578,11 @@ snapshots:
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
@@ -8115,6 +8617,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/template': 7.29.7
+
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -8122,6 +8630,41 @@ snapshots:
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
@@ -8142,12 +8685,62 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-systemjs@7.29.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
@@ -8161,7 +8754,17 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -8174,6 +8777,14 @@ snapshots:
       '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8212,6 +8823,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -8241,6 +8857,22 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-regenerator@7.29.8(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -8253,6 +8885,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-spread@7.29.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -8264,11 +8924,112 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-import-assertions': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-arrow-functions': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-block-scoped-functions': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-class-static-block': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-computed-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-dotall-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-duplicate-keys': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-explicit-resource-management': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-exponentiation-operator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-export-namespace-from': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-function-name': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-json-strings': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-literals': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-logical-assignment-operators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-member-expression-literals': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-modules-amd': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-systemjs': 7.29.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-modules-umd': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-new-target': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-numeric-separator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-object-rest-spread': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-object-super': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-parameters': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-property-literals': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-regenerator': 7.29.8(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-regexp-modifiers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-reserved-words': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-shorthand-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-spread': 7.29.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-sticky-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-template-literals': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-typeof-symbol': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-escapes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-property-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-sets-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@10.2.2))
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      core-js-compat: 3.49.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@10.2.2))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/types': 7.29.7
+      esutils: 2.0.3
 
   '@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
@@ -8308,6 +9069,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.8(supports-color@10.2.2)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/traverse@8.0.4':
     dependencies:
       '@babel/code-frame': 8.0.0
@@ -8320,6 +9093,11 @@ snapshots:
     optional: true
 
   '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -9656,6 +10434,9 @@ snapshots:
     optional: true
 
   '@next/swc-win32-x64-msvc@16.2.12':
+    optional: true
+
+  '@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -11370,6 +12151,12 @@ snapshots:
 
   ansis@4.3.1: {}
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+    optional: true
+
   arg@5.0.2: {}
 
   argparse@1.0.10:
@@ -11419,6 +12206,14 @@ snapshots:
       - supports-color
 
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      core-js-compat: 3.49.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
@@ -11507,6 +12302,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -11528,6 +12325,9 @@ snapshots:
 
   big-integer@1.6.52: {}
 
+  binary-extensions@2.3.0:
+    optional: true
+
   blake3-wasm@2.1.5: {}
 
   bplist-creator@0.1.0:
@@ -11541,6 +12341,11 @@ snapshots:
   bplist-parser@0.3.2:
     dependencies:
       big-integer: 1.6.52
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.8:
     dependencies:
@@ -11601,6 +12406,19 @@ snapshots:
   character-reference-invalid@2.0.1: {}
 
   chardet@2.2.0: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    optional: true
 
   chokidar@5.0.0:
     dependencies:
@@ -11685,6 +12503,8 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@6.2.1: {}
+
   commander@7.2.0: {}
 
   commander@8.3.0: {}
@@ -11706,6 +12526,8 @@ snapshots:
       - supports-color
 
   compute-scroll-into-view@3.1.1: {}
+
+  concat-map@0.0.1: {}
 
   connect@3.7.0(supports-color@10.2.2):
     dependencies:
@@ -12179,6 +13001,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  esutils@2.0.3: {}
+
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
@@ -12379,6 +13203,10 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fs-readdir-recursive@1.1.0: {}
+
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -12536,6 +13364,15 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   globby@11.1.0:
     dependencies:
@@ -12748,6 +13585,11 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
@@ -12766,6 +13608,11 @@ snapshots:
     dependencies:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+    optional: true
 
   is-core-module@2.16.2:
     dependencies:
@@ -13111,6 +13958,11 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+
+  make-dir@2.1.0:
+    dependencies:
+      pify: 4.0.1
+      semver: 5.7.2
 
   make-dir@4.0.0:
     dependencies:
@@ -13800,6 +14652,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.8
 
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.18
+
   minipass@7.1.3: {}
 
   mkdirp@1.0.4: {}
@@ -13897,6 +14753,9 @@ snapshots:
 
   node-releases@2.0.51: {}
 
+  normalize-path@3.0.0:
+    optional: true
+
   npm-package-arg@11.0.3:
     dependencies:
       hosted-git-info: 7.0.2
@@ -13921,6 +14780,10 @@ snapshots:
       ee-first: 1.1.1
 
   on-headers@1.1.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@2.0.1:
     dependencies:
@@ -14047,6 +14910,8 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -14261,6 +15126,11 @@ snapshots:
       js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+    optional: true
 
   readdirp@5.0.0: {}
 
@@ -14527,6 +15397,8 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.1
 
+  semver@5.7.2: {}
+
   semver@6.3.1: {}
 
   semver@7.8.5: {}
@@ -14666,6 +15538,8 @@ snapshots:
       plist: 3.1.1
 
   sisteransi@1.0.5: {}
+
+  slash@2.0.0: {}
 
   slash@3.0.0: {}
 
@@ -15185,6 +16059,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   ws@7.5.13: {}
 

--- a/website/content/integrations/babel.mdx
+++ b/website/content/integrations/babel.mdx
@@ -98,7 +98,7 @@ module.exports = withSayKit(getDefaultConfig(__dirname));
 
 The Babel plugin runs the matching SayKit transformer over every non-`node_modules` source file, rewriting macros to `say.call(...)` invocations.
 
-It also resolves each catalogue import: the locale's [fallback chain](/core-concepts/configuration#fallback-locales) is walked, every file in it parsed with the bucket's formatter, and the results merged into one record so untranslated keys fall back through the chain to the source string.
+Assembling a catalogue means walking the locale's [fallback chain](/core-concepts/configuration#fallback-locales), parsing every file in it with the bucket's formatter, and merging the results into one record so untranslated keys fall back through the chain to the source string. Under the default `'inline'` mode the plugin does that itself, at the import; under `'module'` it leaves the import alone and the Next.js loader or Metro transformer assembles the record instead.
 
 The result: no `.po` parser at runtime, no SayKit extractor in the bundle, just small `say.call()` calls and one plain JS object per locale.
 

--- a/website/content/integrations/babel.mdx
+++ b/website/content/integrations/babel.mdx
@@ -30,25 +30,17 @@ pnpm add -D @saykit/config @saykit/format-po @saykit/transform-js @saykit/transf
 
 Adding a `.babelrc` switches Next.js from SWC to Babel for compilation. SayKit doesn't have a SWC plugin, so this is the supported way to use SayKit with Next.js today.
 
-`catalogues: 'module'` hands catalogues to a loader instead of inlining them — see [Catalogues](#catalogues). Register it for your catalogue extension:
+`catalogues: 'module'` hands catalogues to a loader instead of inlining them — see [Catalogues](#catalogues). Wrap your Next config to register it:
 
 ```js title="next.config.mjs"
-const catalogue = { loaders: ['babel-plugin-saykit/webpack'], as: '*.js' };
+import { withSayKit } from 'babel-plugin-saykit/next';
 
-export default {
-  turbopack: {
-    rules: { '*.po': catalogue },
-  },
-
-  // Turbopack is the default, but `next --webpack` needs the same rule.
-  webpack: (config) => {
-    config.module.rules.push({ test: /\.po$/, use: 'babel-plugin-saykit/webpack' });
-    return config;
-  },
-};
+export default withSayKit({
+  // your config
+});
 ```
 
-Match the rule to your bucket's extension. A `.json` bucket needs `'*.json'` and `/\.json$/` instead — webpack and Turbopack resolve JSON natively, so without a rule the import quietly resolves to the raw file rather than the assembled record.
+`withSayKit` derives the rules from your `saykit.config.*`, one per bucket, for both Turbopack and `next --webpack`. Each targets that bucket's `output` exactly, so changing a bucket's path or format needs no change here, and no other file of the same extension is routed through the loader.
 
 ### Generic Babel
 
@@ -124,16 +116,11 @@ That is usually fine for a plain Babel build or a library, and painful in a dev 
 
 ### `'module'`
 
-The import is left alone, and the catalogue is served by a bundler integration — `babel-plugin-saykit/webpack` for webpack and Turbopack, `babel-plugin-saykit/metro` for Metro. Catalogues stay **real modules**, which is exactly what makes them hot-reloadable.
+The import is left alone, and the catalogue is served by a bundler integration — `babel-plugin-saykit/next` for Next.js, `babel-plugin-saykit/metro` for Metro. Catalogues stay **real modules**, which is exactly what makes them hot-reloadable.
 
 Set it whenever one of those is wired up. The two are mutually exclusive: if the plugin inlines the import, the integration is never asked for the module and nothing hot-reloads.
 
-<Callout type="warn">
-  Under `'module'`, every catalogue extension needs a rule. webpack and Turbopack resolve `.json`
-  natively, so a **JSON bucket without its own rule** silently hands the importer the raw file
-  instead of the assembled record — the locale's own keys work and every fallback key is missing at
-  runtime. Register a rule per extension you use, `.json` included.
-</Callout>
+Those two are the whole list, because they are the two bundlers that cannot be reached any other way — Metro never runs Babel over `.json`, and Turbopack runs loaders but not plugins. On webpack, Vite, Rollup or esbuild proper, use [`unplugin-saykit`](/integrations/unplugin) and skip the Babel plugin's catalogue handling entirely.
 
 <Callout type="info">
   Under webpack and Turbopack the fallback files are registered as dependencies too, so editing a

--- a/website/content/integrations/babel.mdx
+++ b/website/content/integrations/babel.mdx
@@ -30,6 +30,24 @@ pnpm add -D @saykit/config @saykit/format-po @saykit/transform-js @saykit/transf
 
 Adding a `.babelrc` switches Next.js from SWC to Babel for compilation. SayKit doesn't have a SWC plugin, so this is the supported way to use SayKit with Next.js today.
 
+Catalogues are assembled by a loader rather than by the Babel plugin, so register it for your catalogue extension too:
+
+```js title="next.config.mjs"
+const catalogue = { loaders: ['babel-plugin-saykit/webpack'], as: '*.js' };
+
+export default {
+  turbopack: {
+    rules: { '*.po': catalogue },
+  },
+
+  // Turbopack is the default, but `next --webpack` needs the same rule.
+  webpack: (config) => {
+    config.module.rules.push({ test: /\.po$/, use: 'babel-plugin-saykit/webpack' });
+    return config;
+  },
+};
+```
+
 ### Generic Babel
 
 ```js title="babel.config.js"
@@ -71,19 +89,43 @@ module.exports = function (api) {
 };
 ```
 
+Metro never runs Babel over `.json`, so catalogues are assembled by a transform worker instead. Wrap your Metro config:
+
+```js title="metro.config.js"
+const { getDefaultConfig } = require('expo/metro-config');
+const { withSayKit } = require('babel-plugin-saykit/metro');
+
+module.exports = withSayKit(getDefaultConfig(__dirname));
+```
+
+`withSayKit` also registers non-JSON catalogue extensions (e.g. `.po`) with Metro's resolver, since a file Metro cannot resolve is not a module it can reload.
+
 ## What it does
 
-For every non-`node_modules` source file passed through Babel, the plugin:
+The Babel plugin runs the matching SayKit transformer over every non-`node_modules` source file, rewriting macros to `say.call(...)` invocations.
 
-1. Runs the matching SayKit transformer over the source, rewriting macros to `say.call(...)` invocations.
-2. Watches for static imports of translation files (e.g. `import fr from './locales/fr.po'`), resolves that locale's [fallback chain](/core-concepts/configuration#fallback-locales), parses each file in it with the bucket's formatter, and inlines the merged catalogue as a JS object literal in place of the import, untranslated keys falling back through the chain to the source string.
+Catalogues are handled separately, by whichever module pipeline your bundler uses — `babel-plugin-saykit/webpack` for webpack and Turbopack, `babel-plugin-saykit/metro` for Metro. Each resolves the locale's [fallback chain](/core-concepts/configuration#fallback-locales), parses every file in it with the bucket's formatter, and replaces the catalogue with the merged record, untranslated keys falling back through the chain to the source string.
 
-The result: no `.po` file at runtime, no SayKit extractor in the bundle, just small `say.call()` calls and plain JS objects, one locale per module. Each file in the chain is registered as an external dependency so Babel re-runs when the source locale changes.
+The result: no `.po` parser at runtime, no SayKit extractor in the bundle, just small `say.call()` calls and one plain JS object per locale.
+
+<Callout type="info">
+  Catalogues stay **real modules** rather than being inlined into whoever imports them. That is what
+  makes them hot-reloadable: a bundler invalidates a module when its own bytes change, so a record
+  inlined into an importer could never be invalidated at all. Under webpack and Turbopack the
+  fallback files are registered as dependencies too, so editing a source locale updates every locale
+  that falls back to it.
+</Callout>
 
 <Callout type="warn">
-  The plugin currently only rewrites **static** imports. `import('./locales/en.po')` (dynamic
-  import) is not yet replaced. For dynamic locale loading, use a `Say` loader and let your bundler
-  handle the imports.
+  Under **Metro** only the locale's own file is tracked. Metro keys its transform cache on each
+  file's bytes and offers no equivalent of `addDependency`, so editing a *fallback* locale (e.g.
+  `en.json` while viewing `fr`) does not refresh the locale that falls back to it. Editing the
+  locale you are viewing works normally.
+</Callout>
+
+<Callout type="warn">
+  Only **static** imports of catalogues are handled. `import('./locales/en.po')` (dynamic import) is
+  not. For dynamic locale loading, use a `Say` loader and let your bundler handle the imports.
 </Callout>
 
 ## `unplugin` vs Babel: which one?

--- a/website/content/integrations/babel.mdx
+++ b/website/content/integrations/babel.mdx
@@ -24,13 +24,13 @@ pnpm add -D @saykit/config @saykit/format-po @saykit/transform-js @saykit/transf
 ```json title=".babelrc"
 {
   "presets": ["next/babel"],
-  "plugins": ["saykit"]
+  "plugins": [["saykit", { "catalogues": "module" }]]
 }
 ```
 
 Adding a `.babelrc` switches Next.js from SWC to Babel for compilation. SayKit doesn't have a SWC plugin, so this is the supported way to use SayKit with Next.js today.
 
-Catalogues are assembled by a loader rather than by the Babel plugin, so register it for your catalogue extension too:
+`catalogues: 'module'` hands catalogues to a loader instead of inlining them — see [Catalogues](#catalogues). Register it for your catalogue extension:
 
 ```js title="next.config.mjs"
 const catalogue = { loaders: ['babel-plugin-saykit/webpack'], as: '*.js' };
@@ -47,6 +47,8 @@ export default {
   },
 };
 ```
+
+Match the rule to your bucket's extension. A `.json` bucket needs `'*.json'` and `/\.json$/` instead — webpack and Turbopack resolve JSON natively, so without a rule the import quietly resolves to the raw file rather than the assembled record.
 
 ### Generic Babel
 
@@ -71,7 +73,7 @@ React Native uses Babel via Metro. Add the plugin to your Babel config:
 ```js title="babel.config.js"
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  plugins: ['saykit'],
+  plugins: [['saykit', { catalogues: 'module' }]],
 };
 ```
 
@@ -84,7 +86,7 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['saykit'],
+    plugins: [['saykit', { catalogues: 'module' }]],
   };
 };
 ```
@@ -104,16 +106,38 @@ module.exports = withSayKit(getDefaultConfig(__dirname));
 
 The Babel plugin runs the matching SayKit transformer over every non-`node_modules` source file, rewriting macros to `say.call(...)` invocations.
 
-Catalogues are handled separately, by whichever module pipeline your bundler uses — `babel-plugin-saykit/webpack` for webpack and Turbopack, `babel-plugin-saykit/metro` for Metro. Each resolves the locale's [fallback chain](/core-concepts/configuration#fallback-locales), parses every file in it with the bucket's formatter, and replaces the catalogue with the merged record, untranslated keys falling back through the chain to the source string.
+It also resolves each catalogue import: the locale's [fallback chain](/core-concepts/configuration#fallback-locales) is walked, every file in it parsed with the bucket's formatter, and the results merged into one record so untranslated keys fall back through the chain to the source string.
 
 The result: no `.po` parser at runtime, no SayKit extractor in the bundle, just small `say.call()` calls and one plain JS object per locale.
 
+## Catalogues
+
+Where that record is assembled is controlled by the `catalogues` option, and the choice decides whether editing a catalogue hot-reloads.
+
+### `'inline'` (default)
+
+The import is replaced with the record, in the module that imported it. Babel alone is enough — no bundler configuration at all.
+
+The cost is hot reload. A bundler re-reads a module when that module's own bytes change, and a record baked into an importer lives in a file that does not change when you edit a catalogue. So new and edited strings only appear after a cache-clearing restart (`expo start --clear`, deleting `.next`).
+
+That is usually fine for a plain Babel build or a library, and painful in a dev server.
+
+### `'module'`
+
+The import is left alone, and the catalogue is served by a bundler integration — `babel-plugin-saykit/webpack` for webpack and Turbopack, `babel-plugin-saykit/metro` for Metro. Catalogues stay **real modules**, which is exactly what makes them hot-reloadable.
+
+Set it whenever one of those is wired up. The two are mutually exclusive: if the plugin inlines the import, the integration is never asked for the module and nothing hot-reloads.
+
+<Callout type="warn">
+  Under `'module'`, every catalogue extension needs a rule. webpack and Turbopack resolve `.json`
+  natively, so a **JSON bucket without its own rule** silently hands the importer the raw file
+  instead of the assembled record — the locale's own keys work and every fallback key is missing at
+  runtime. Register a rule per extension you use, `.json` included.
+</Callout>
+
 <Callout type="info">
-  Catalogues stay **real modules** rather than being inlined into whoever imports them. That is what
-  makes them hot-reloadable: a bundler invalidates a module when its own bytes change, so a record
-  inlined into an importer could never be invalidated at all. Under webpack and Turbopack the
-  fallback files are registered as dependencies too, so editing a source locale updates every locale
-  that falls back to it.
+  Under webpack and Turbopack the fallback files are registered as dependencies too, so editing a
+  source locale updates every locale that falls back to it.
 </Callout>
 
 <Callout type="warn">


### PR DESCRIPTION
Fixes #71.

Catalogues were inlined into whoever imported them, which bakes the record into a module whose own bytes never change. No bundler can invalidate on that, so editing a catalogue did nothing until a cache-clearing restart (`expo start --clear`). Next.js was affected identically.

`addExternalDependency` could never have helped: Babel freezes the array the moment the plugin factory returns (`config/helpers/deep-array.js` → `Object.freeze`), so calling it from a visitor always threw into the `catch {}`. And neither Metro nor Next consumes `externalDependencies` anyway — Next declares it in its loader's config type and never turns it into a webpack dependency. Full analysis in the issue.

## Approach

Catalogues stay real modules, assembled by each bundler's own module pipeline — the only layer with an invalidation signal.

```
packages/plugin-babel/src/
  catalogue.ts          shared: resolve fallback chain → assembled record
  metro/index.ts        withSayKit(metroConfig)
  metro/transformer.ts  transform worker wrapper
  next/index.ts         withSayKit(nextConfig)
  next/loader.ts        the loader those rules point at
  index.ts              parserOverride + the inlining visitor
```

Metro needs a transform worker rather than a loader because it routes `.json` straight through `transformJSON` and never runs Babel over it. `withSayKit` also registers non-JSON catalogue extensions with Metro's resolver, since a file Metro can't resolve isn't a module it can reload.

These two are the whole list of integrations, because they are the two bundlers not reachable any other way. On webpack, Vite, Rollup or esbuild proper, `unplugin-saykit` already does this through each bundler's own plugin API — there is no `babel-plugin-saykit/webpack`, and the loader is published only as `./next/loader` so Turbopack can name it in a rule.

## Assembly is opt-in

Inlining stays the default, so `babel-plugin-saykit` on its own behaves exactly as before and this is not a breaking change.

```js
// Babel alone — inlines, no bundler config, no hot reload (the old behaviour)
plugins: ['saykit'];

// With a bundler integration — real modules, hot reload
plugins: [['saykit', { catalogues: 'module' }]];
```

The two are mutually exclusive by nature: if the plugin inlines the import, the integration is never asked for the module. Hence an explicit option rather than a default flip.

## Next.js setup is one line

`withSayKit` derives the rules from `saykit.config.*` rather than asking you to hand-write them:

```js
// next.config.mjs
import { withSayKit } from 'babel-plugin-saykit/next';
export default withSayKit({});
```

One rule per bucket, for Turbopack and for `next --webpack`, each targeting that bucket's `output` exactly — a Turbopack glob built from the `output` template, and a webpack predicate. That removes two footguns that were previously documentation warnings:

- **A JSON bucket needed its own rule**, and silently served the raw file without one. Now generated automatically.
- **A `.json` rule would have swept up every JSON import in the app.** Deriving from `output` means only catalogues match. The generated rules also declare the loader's output as JavaScript (`type: 'javascript/auto'`, `as: '*.js'`), which webpack does not assume for `.json`.

## Verified against running dev servers

| | Test | Result |
|---|---|---|
| Next.js | edit `fr.po` with the server running | ✅ picked up |
| Next.js | edit `en.po` while viewing `/fr` (fallback-only dependency) | ✅ picked up via `addDependency` |
| Expo/Metro | edit `fr.json` with Metro running, no `--clear` | ✅ picked up |
| Expo/Metro | edit `en.json` while `fr` falls back to it | ❌ still stale |

`next build` (Turbopack) prerenders `/en`, `/fr`, `/pl` with translations in place. `next build --webpack` fails in the example, but on `@messageformat/parser` being transpiled by Next's bundled Babel — a `node_modules` file no catalogue rule touches, and unrelated to this PR. So the webpack half of `withSayKit` is covered by unit tests (rule shape, and the predicate matching catalogues but not neighbouring source files) rather than a real build.

429 tests, `pnpm check` 19/19, lint and format clean.

## Known gap (Metro only)

Metro keys its transform cache on each file's own bytes, and `getCacheKey` takes no filename — it is one global key — so there is no hook to hang a fallback chain's contents on. A fallback locale's contents baked into another locale's record can't be invalidated. Documented as a callout on the Babel integration page. Editing the locale you're viewing — the case in the issue — works.

Tracked as #81, with the analysis: the fix is emitting `module.exports = Object.assign({}, require('./en.json'), {…})` so the merge happens over real module edges. Two things make it its own PR — `metro-transform-worker` routes `.json` into `transformJSON`, which never scans for dependencies, and each module has to emit its translations only so a fallback's `msgid` can't outrank a real translation.

## Also in here

- **Metro upstream resolution** bases off the config's `projectRoot` instead of `process.cwd()`, so `--config` and monorepo layouts resolve the project's own Metro. Falls back to this package's resolver for hoisted installs. `withSayKit` is now a no-op if it would wrap its own transformer, which would otherwise recurse until the worker died.
- **Metro cache key** is salted with the `saykit.config.*` contents and this package's version. Previously, editing the fallback chain or a bucket formatter left every catalogue serving its cached record. The config path comes from the new `resolveConfigFile`, so it cannot silently disagree with the config that was actually loaded.
- **`examples/babel`** — Babel and nothing else, `babel src --out-dir dist` then `node dist/main.js`. Every other example runs the plugin alongside a bundler, so this is the only one that would notice if the inlining default broke.
- **Catalogue loading is synchronous**, one implementation shared by all three callers. Babel's visitor can't await, and a fallback chain is a handful of files in a pipeline that blocks on the result anyway.
- `@saykit/config` exports `resolveConfigFile`.
- Fixed the package's `types` paths, which pointed at `.d.cjs` while tsdown emits `.d.cts` — TS consumers were getting no types at all.
