### PR TITLE
Validate ICU branch keys where the macro is transformed

### DIFF
--- a/.changeset/hungry-pugs-repeat.md
+++ b/.changeset/hungry-pugs-repeat.md
@@ -1,0 +1,7 @@
+---
+'@saykit/config': patch
+'@saykit/transform-js': patch
+'@saykit/transform-jsx': patch
+---
+
+Fail the build on a select or plural branch key ICU cannot express, rather than at format time

--- a/.changeset/hungry-pugs-repeat.md
+++ b/.changeset/hungry-pugs-repeat.md
@@ -4,4 +4,4 @@
 '@saykit/transform-jsx': patch
 ---
 
-Fail the build on a select or plural branch key ICU cannot express, rather than at format time
+Fail the build on a select, plural, or ordinal branch key ICU cannot express, rather than at format time

--- a/packages/config/src/features/messages/convert.ts
+++ b/packages/config/src/features/messages/convert.ts
@@ -1,3 +1,4 @@
+import { getBranchCase } from './identifier.js';
 import {
   ArgumentMessage,
   ChoiceMessage,
@@ -29,9 +30,7 @@ export function convertMessageToIcu(message: Message) {
       case message instanceof ChoiceMessage: {
         const branches = message.branches
           .map(({ identifier, value }) => ({
-            identifier: Number.isNaN(+String(identifier))
-              ? String(identifier)
-              : `=${+String(identifier)}`,
+            identifier: getBranchCase(identifier),
             value: internalConvertMessageToIcu(value),
           }))
           .map(({ identifier, value }) => `  ${identifier} {${value}}\n`)

--- a/packages/config/src/features/messages/identifier.test.ts
+++ b/packages/config/src/features/messages/identifier.test.ts
@@ -182,6 +182,12 @@ describe('getBranchCase', () => {
   it('writes a number as an exact value', () => {
     expect(getBranchCase('0')).toBe('=0');
   });
+
+  // Everything JavaScript is willing to call a number is not one, and coercing
+  // these would hand back a case that selects zero.
+  it.each(['', ' ', '+0', '1e3'])('leaves %o a key rather than an exact value', (key) => {
+    expect(getBranchCase(key)).toBe(key);
+  });
 });
 
 describe('validateBranchIdentifier', () => {
@@ -222,6 +228,12 @@ describe('validateBranchIdentifier', () => {
 
   it('omits a suggestion that would itself be an exact value', () => {
     expect(() => validateBranchIdentifier('select', '1.5')).not.toThrow(/try/);
+  });
+
+  it.each(['', ' ', '+0'])('rejects the numeric-looking key %o', (key) => {
+    expect(() => validateBranchIdentifier('plural', key)).toThrow(
+      'an ICU key cannot contain punctuation or whitespace',
+    );
   });
 
   it('rejects an exact value on a select', () => {

--- a/packages/config/src/features/messages/identifier.test.ts
+++ b/packages/config/src/features/messages/identifier.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { assignSequenceIdentifiers } from './identifier.js';
+import {
+  assignSequenceIdentifiers,
+  getBranchCase,
+  validateBranchIdentifier,
+} from './identifier.js';
 import {
   ArgumentMessage,
   AUTO_INCREMENT_IDENTIFIER,
@@ -167,5 +171,62 @@ describe('assignSequenceIdentifiers', () => {
   it('leaves a literal message unchanged', () => {
     const literal = new LiteralMessage('hi');
     expect(() => assignSequenceIdentifiers(literal)).not.toThrow();
+  });
+});
+
+describe('getBranchCase', () => {
+  it('writes a key as itself', () => {
+    expect(getBranchCase('other')).toBe('other');
+  });
+
+  it('writes a number as an exact value', () => {
+    expect(getBranchCase('0')).toBe('=0');
+  });
+});
+
+describe('validateBranchIdentifier', () => {
+  it('accepts a plain key', () => {
+    expect(() => validateBranchIdentifier('select', 'inStock')).not.toThrow();
+  });
+
+  it('accepts a key outside ASCII', () => {
+    expect(() => validateBranchIdentifier('select', 'año')).not.toThrow();
+  });
+
+  it('accepts an exact value on a plural', () => {
+    expect(() => validateBranchIdentifier('plural', '0')).not.toThrow();
+  });
+
+  it('accepts a branch still awaiting a sequence number', () => {
+    expect(() => validateBranchIdentifier('select', AUTO_INCREMENT_IDENTIFIER)).not.toThrow();
+  });
+
+  it('rejects a hyphenated key and suggests a camel case one', () => {
+    expect(() => validateBranchIdentifier('select', 'sold-out')).toThrow(
+      "Invalid select branch key 'sold-out', an ICU key cannot contain punctuation or whitespace, try 'soldOut'",
+    );
+  });
+
+  it('names the kind that was written', () => {
+    expect(() => validateBranchIdentifier('ordinal', 'runner up')).toThrow(
+      "Invalid ordinal branch key 'runner up'",
+    );
+  });
+
+  it('omits the suggestion when nothing identifier-safe is left', () => {
+    expect(() => validateBranchIdentifier('select', '--')).toThrow(
+      "Invalid select branch key '--', an ICU key cannot contain punctuation or whitespace",
+    );
+    expect(() => validateBranchIdentifier('select', '--')).not.toThrow(/try/);
+  });
+
+  it('omits a suggestion that would itself be an exact value', () => {
+    expect(() => validateBranchIdentifier('select', '1.5')).not.toThrow(/try/);
+  });
+
+  it('rejects an exact value on a select', () => {
+    expect(() => validateBranchIdentifier('select', '0')).toThrow(
+      "Invalid select branch key '0', a number selects an exact value, which only 'plural' and 'ordinal' accept",
+    );
   });
 });

--- a/packages/config/src/features/messages/identifier.ts
+++ b/packages/config/src/features/messages/identifier.ts
@@ -17,10 +17,16 @@ const BRANCH_PATTERN = /^(?:=\d+|[^\p{Pattern_Syntax}\p{Pattern_White_Space}]+)$
 /**
  * The ICU case a branch is written as. A number names an exact value rather
  * than a key, and only `plural` and `ordinal` are allowed to select on one.
+ *
+ * Digits are read literally rather than coerced, because everything JavaScript
+ * is willing to call a number is not: `''`, `' '`, and `'+0'` all coerce to
+ * `=0`, which would pass for a key that selects zero and quietly leave the
+ * author's own key out of the catalogue. Anything else stays a key, where the
+ * whitespace or punctuation that made it numeric-looking is caught.
  */
 export function getBranchCase(identifier: string | typeof AUTO_INCREMENT_IDENTIFIER) {
   const key = String(identifier);
-  return Number.isNaN(+key) ? key : `=${+key}`;
+  return /^\d+$/u.test(key) ? `=${+key}` : key;
 }
 
 /**

--- a/packages/config/src/features/messages/identifier.ts
+++ b/packages/config/src/features/messages/identifier.ts
@@ -9,6 +9,71 @@ import {
 export const AUTO_INCREMENT_IDENTIFIER = Symbol('auto-increment');
 
 /**
+ * An ICU case, either an exact value or a key. ICU reserves its own pattern
+ * syntax, so a key carries no punctuation and no whitespace.
+ */
+const BRANCH_PATTERN = /^(?:=\d+|[^\p{Pattern_Syntax}\p{Pattern_White_Space}]+)$/u;
+
+/**
+ * The ICU case a branch is written as. A number names an exact value rather
+ * than a key, and only `plural` and `ordinal` are allowed to select on one.
+ */
+export function getBranchCase(identifier: string | typeof AUTO_INCREMENT_IDENTIFIER) {
+  const key = String(identifier);
+  return Number.isNaN(+key) ? key : `=${+key}`;
+}
+
+/**
+ * Reject a branch key ICU cannot express, while the key is still attached to a
+ * file and a line.
+ *
+ * A hyphenated string union is ordinary application code and typechecks,
+ * builds, and extracts to a catalogue entry that looks perfectly normal — the
+ * only sign of trouble is a parse error at format time, in a message whose
+ * source is long gone.
+ */
+export function validateBranchIdentifier(
+  kind: string,
+  identifier: string | typeof AUTO_INCREMENT_IDENTIFIER,
+) {
+  // A branch still awaiting a sequence number is numbered, and a number is
+  // always a well-formed case.
+  if (typeof identifier !== 'string') return;
+
+  const branch = getBranchCase(identifier);
+
+  if (!BRANCH_PATTERN.test(branch)) {
+    const suggestion = suggestBranchIdentifier(identifier);
+    throw new Error(
+      `Invalid ${kind} branch key '${identifier}', an ICU key cannot contain punctuation or whitespace` +
+        (suggestion ? `, try '${suggestion}'` : ''),
+    );
+  }
+
+  if (kind === 'select' && branch.startsWith('='))
+    throw new Error(
+      `Invalid select branch key '${identifier}', a number selects an exact value, which only 'plural' and 'ordinal' accept`,
+    );
+}
+
+/**
+ * The nearest identifier-safe form of a key, so the error names the fix as well
+ * as the problem. The constraint comes from ICU rather than from anything the
+ * author wrote, and camel case is how the rest of the codebase already spells a
+ * name of more than one word.
+ */
+function suggestBranchIdentifier(identifier: string) {
+  const suggestion = identifier
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean)
+    .map((word, index) => (index === 0 ? word : word[0]!.toUpperCase() + word.slice(1)))
+    .join('');
+
+  if (!BRANCH_PATTERN.test(suggestion) || !Number.isNaN(+suggestion)) return undefined;
+  return suggestion;
+}
+
+/**
  * Decides whether two placeholders sharing a name are the same placeholder, and
  * so may share it. Only the syntax that produced them can answer that, so the
  * caller supplies the comparison; by default nothing is interchangeable.

--- a/packages/transform-js/src/index.test.ts
+++ b/packages/transform-js/src/index.test.ts
@@ -62,6 +62,15 @@ describe('createJsTransformer.extract', () => {
     );
   });
 
+  it('throws for a branch key ICU cannot express', () => {
+    expect(() =>
+      transformer.extract(
+        "const s = say.select(status, { 'sold-out': 'Sold out', other: 'In stock' });",
+        'file.ts',
+      ),
+    ).toThrow("Invalid select branch key 'sold-out', an ICU key cannot contain punctuation");
+  });
+
   it('returns an empty array when there are no messages', () => {
     expect(transformer.extract('const x = 1 + 2;', 'file.ts')).toEqual([]);
   });

--- a/packages/transform-js/src/parser.test.ts
+++ b/packages/transform-js/src/parser.test.ts
@@ -292,6 +292,20 @@ describe('parseCallExpression', () => {
     expect(choice.branches[2]!.value).toEqual({ text: 'many' });
   });
 
+  it('throws for a branch key ICU cannot express', () => {
+    expect(() =>
+      parser.parseCallExpression(
+        expr("say.select(status, { 'in-stock': 'In stock', 'sold-out': 'Sold out' })"),
+      ),
+    ).toThrow("Invalid select branch key 'in-stock'");
+  });
+
+  it('throws for an exact match on a select', () => {
+    expect(() =>
+      parser.parseCallExpression(expr("say.select(status, { 0: 'none', other: 'some' })")),
+    ).toThrow("Invalid select branch key '0'");
+  });
+
   it('returns null when the callee is not a say expression', () => {
     expect(parser.parseCallExpression(expr("other.plural(count, { other: 'x' })"))).toBeNull();
   });

--- a/packages/transform-js/src/parser.ts
+++ b/packages/transform-js/src/parser.ts
@@ -5,6 +5,7 @@ import {
   CompositeMessage,
   AUTO_INCREMENT_IDENTIFIER,
   LiteralMessage,
+  validateBranchIdentifier,
   type Message,
 } from '@saykit/config/features/messages';
 
@@ -65,6 +66,8 @@ export function parseCallExpression(call: t.CallExpression): CompositeMessage | 
 
       return c;
     }, []);
+
+    for (const branch of branches) validateBranchIdentifier(kind, branch.identifier);
 
     const [identifier, value] = unwrapPlaceholder(call.arguments[0]);
     const choice = new ChoiceMessage(kind, identifier, branches, value);

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -101,6 +101,23 @@ describe('createJsxTransformer.extract', () => {
     ).toThrow("Invalid placeholder name 'who is'");
   });
 
+  it('throws for a branch key ICU cannot express', () => {
+    expect(() =>
+      transformer.extract(
+        'const x = <Say.Select _={status} in-stock="In stock" other="Sold out" />;',
+        'file.tsx',
+      ),
+    ).toThrow("Invalid select branch key 'in-stock'");
+  });
+
+  it('keeps an underscored numeric branch key an exact match', () => {
+    const [message] = transformer.extract(
+      'const x = <Say.Plural _={count} _0="none" other="# items" />;',
+      'file.tsx',
+    );
+    expect(message!.message).toContain('=0 {none}');
+  });
+
   it('extracts childless elements as self-closing tags', () => {
     const [message] = transformer.extract('const x = <Say>Open <ChevronDown /></Say>;', 'file.tsx');
     expect(message!.message).toBe('Open <0/>');

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -6,6 +6,7 @@ import {
   CompositeMessage,
   ElementMessage,
   LiteralMessage,
+  validateBranchIdentifier,
   type Message,
 } from '@saykit/config/features/messages';
 import { unwrapPlaceholder } from '@saykit/transform-js/parser';
@@ -106,6 +107,8 @@ export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeM
 
       return b;
     }, []);
+
+    for (const branch of branches) validateBranchIdentifier(kind, branch.identifier);
 
     const initialiser = findAttributeValueIfExpressionOrStringLiteral(element.attributes, '_');
     if (!initialiser) return null;

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -206,6 +206,11 @@ Extracted:
 }
 ```
 
+A branch key is an ICU key, so it carries no punctuation and no whitespace. A hyphenated string
+union is ordinary TypeScript but not an ICU key, and `'sold-out'` fails the build naming the key and
+the camel case form to use instead. Numbers are the exception: they select an exact value, which
+only `say.plural` and `say.ordinal` accept.
+
 ## Descriptors
 
 A descriptor is an object passed to `say` before the template. It carries metadata that affects extraction.


### PR DESCRIPTION
Closes #54.

A `select` or `plural` branch key that is not a valid ICU key passed every stage of the toolchain and only failed when the runtime handed the pattern to `@messageformat/parser`. The constraint lives in that lexer, where a case is `=\d+` or `[^\p{Pat_Syn}\p{Pat_WS}]+` — and `-` is Pattern_Syntax, so an ordinary hyphenated string union (`'sold-out'`) extracted to a normal-looking catalogue entry and then died with `invalid syntax at line 2 col 3`.

Validation now runs where the macro is transformed, while the key is still attached to a file and a line:

```
Invalid select branch key 'sold-out', an ICU key cannot contain punctuation or whitespace, try 'soldOut'
```

- `validateBranchIdentifier` and `getBranchCase` live in `@saykit/config`, and `convertMessageToIcu` writes its cases through `getBranchCase`, so what is validated and what is emitted cannot drift.
- Both parsers validate their collected branches. JSX attribute names accept hyphens too, so `<Say.Select in-stock="…">` had the same hole.
- The check is ICU's own rule rather than the stricter ASCII pattern used for placeholder names, so a key like `año` stays legal.

Numeric keys are the one adjacent case included: a number compiles to an exact-value case (`=0`), which only `plural` and `ordinal` accept, so `say.select(x, { 0: … })` was failing at format time for the same reason. It now errors with the reason named.

The error is a plain `Error`, matching the existing `Invalid placeholder name` and `say-tag` validation — the filename comes from the bundler reporting which module threw. Naming the file and line in the message text would be a separate change across all three validators.

Docs get a paragraph under Select, and there are tests for the validator, both parsers, and both extractors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Builds now catch invalid ICU branch keys earlier, rather than failing during message formatting.
  - Select, plural, and ordinal branches now validate punctuation, whitespace, numeric values, and unsupported exact-match cases.
  - Numeric plural and ordinal branches are converted to the correct ICU exact-value format.

- **Documentation**
  - Added guidance on valid branch keys, including restrictions for `select` and numeric keys.

- **Tests**
  - Expanded coverage for invalid keys, exact numeric matches, validation errors, and suggested corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->