### PR TITLE
Extract JSX whitespace exactly as JSX renders it

### DIFF
--- a/.changeset/light-donkeys-hear.md
+++ b/.changeset/light-donkeys-hear.md
@@ -1,0 +1,5 @@
+---
+'@saykit/transform-jsx': minor
+---
+
+Extract JSX whitespace exactly as JSX renders it, and read a literal expression child such as `{' '}` or `{10}` as the text it renders as

--- a/examples/expo/src/habit-card.tsx
+++ b/examples/expo/src/habit-card.tsx
@@ -28,7 +28,7 @@ export function HabitCard({ habit, onToggle }: { habit: Habit; onToggle: () => v
 
       <Text style={styles.progress}>
         <Say>
-          <Text style={styles.strong}>{habit.thisWeek}</Text> of
+          <Text style={styles.strong}>{habit.thisWeek}</Text> of{' '}
           <Text style={styles.strong}>{habit.target}</Text> this week
         </Say>
       </Text>

--- a/examples/react/src/components/board.tsx
+++ b/examples/react/src/components/board.tsx
@@ -33,7 +33,7 @@ function BoardColumn({ column }: { column: Column }) {
             still uses these exact React elements, with their handlers intact.
           */}
           <Say>
-            Nothing here. <a href="#new">Add a task</a> or drag one across from
+            Nothing here. <a href="#new">Add a task</a> or drag one across from{' '}
             <strong>To do</strong>.
           </Say>
         </p>
@@ -62,7 +62,7 @@ export function Board() {
             `one` and `other`.
           */}
           <Say>
-            Welcome back, {currentMember}. This is your
+            Welcome back, {currentMember}. This is your{' '}
             <Say.Ordinal _={sprintNumber} one="#st" two="#nd" few="#rd" other="#th" /> sprint.
           </Say>
         </p>
@@ -87,7 +87,7 @@ export function Board() {
           */}
           <Say>
             <Say.Number _={{ complete: completionRatio() }} style="percent" /> complete. This sprint
-            ends on <Say.Date _={{ sprintEndsAt }} style="medium" />, at
+            ends on <Say.Date _={{ sprintEndsAt }} style="medium" />, at{' '}
             <Say.Time _={{ sprintEndsAt }} style="short" />.
           </Say>
         </p>

--- a/examples/tanstack-start/src/routes/{-$locale}/index.tsx
+++ b/examples/tanstack-start/src/routes/{-$locale}/index.tsx
@@ -58,14 +58,14 @@ function SessionRow({ session }: { session: Session }) {
               <>
                 {' — '}
                 <Say>
-                  their
+                  their{' '}
                   <Say.Ordinal
                     _={session.previousTalks + 1}
                     one="#st"
                     two="#nd"
                     few="#rd"
                     other="#th"
-                  />
+                  />{' '}
                   time on this stage
                 </Say>
               </>
@@ -108,9 +108,8 @@ function SchedulePage() {
             free through the fallback chain, without restating it.
           */}
           <Say>
-            The full program —
-            <Say.Plural _={sessions.length} one="# session" other="# sessions" />, including
-            <Say.Plural _={workshops} one="# workshop" other="# workshops" />.
+            The full program — <Say.Plural _={sessions.length} one="# session" other="# sessions" />
+            , including <Say.Plural _={workshops} one="# workshop" other="# workshops" />.
           </Say>
         </p>
       </header>

--- a/packages/transform-jsx/src/parser.test.ts
+++ b/packages/transform-jsx/src/parser.test.ts
@@ -64,10 +64,26 @@ describe('parseJSXContainerElement', () => {
     expect(result!.descriptor).toEqual({ id: 'msg', context: 'nav' });
   });
 
-  it('drops text children that are only whitespace', () => {
-    const result = parser.parseJSXContainerElement(jsx`<Say>{name}   </Say>`);
+  it('drops text children that are only a line break and indentation', () => {
+    const result = parser.parseJSXContainerElement(jsx`
+      <Say>
+        {name}
+      </Say>
+    `);
     expect(result!.children).toHaveLength(1);
     expect(result!.children[0]).toBeInstanceOf(ArgumentMessage);
+  });
+
+  it('parses a literal string expression as text, folded into its neighbour', () => {
+    const result = parser.parseJSXContainerElement(jsx`<Say>Hello,{' '}world</Say>`);
+    expect(result!.children).toEqual([new LiteralMessage('Hello, world')]);
+  });
+
+  // A spread child renders an unknown number of unknown things, so there is
+  // nothing to name it or to translate around it.
+  it('ignores spread children', () => {
+    const result = parser.parseJSXContainerElement(jsx`<Say>{...items}</Say>`);
+    expect(result!.children).toHaveLength(0);
   });
 
   it('ignores expression containers that hold no expression', () => {

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -202,6 +202,20 @@ function getExpressionAsLiteralText(expression: t.Node) {
   // A number renders as the text `String()` makes of it, and reads as content
   // in the sentence rather than as a value anything supplies.
   if (t.isNumericLiteral(expression)) return String(expression.value);
+  // A signed number is a unary operator applied to a literal rather than a
+  // literal of its own, but `{-1}` is still a number written into a sentence.
+  if (
+    t.isUnaryExpression(expression) &&
+    (expression.operator === '-' || expression.operator === '+') &&
+    t.isNumericLiteral(expression.argument)
+  ) {
+    return String(
+      expression.operator === '-' ? -expression.argument.value : expression.argument.value,
+    );
+  }
+  // JSX renders no child at all for these, so the sentence has a gap where the
+  // expression is and nothing to put in it.
+  if (t.isBooleanLiteral(expression) || t.isNullLiteral(expression)) return '';
   // A template literal with nothing interpolated is a string literal written
   // with different quotes, and renders as one.
   if (t.isTemplateLiteral(expression) && expression.expressions.length === 0) {

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -29,21 +29,24 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
   if (!processed) return null;
   const [accessor] = processed;
 
-  const children = element.children.reduce<Message[]>((p, c, i, a) => {
-    if (t.isJSXText(c)) {
-      const text = normalizeJSXText(c.value, i === 0, i === a.length - 1);
-      if (text) p.push(new LiteralMessage(text));
-    }
+  // The children the JSX transform itself would compile, so a message extracts
+  // as the text that renders. Text children come back with their whitespace
+  // collapsed the way JSX collapses it — a line break and the indentation
+  // around it are layout and disappear, while two lines that both hold text
+  // rejoin with the single space that separated the words — every expression
+  // container comes back unwrapped, and a comment child comes back as nothing.
+  const children = t.react.buildChildren(element).reduce<Message[]>((p, c) => {
+    const literal = getExpressionAsLiteralText(c);
 
-    if (t.isJSXElement(c)) {
+    if (literal !== undefined) {
+      pushLiteral(p, literal);
+    } else if (t.isJSXElement(c)) {
       p.push(parseJSXElement(c, true));
     } else if (t.isJSXFragment(c)) {
       p.push(new ElementMessage(AUTO_INCREMENT_IDENTIFIER, [], c));
-    } else if (t.isJSXExpressionContainer(c)) {
-      if (t.isExpression(c.expression)) {
-        const [identifier, value] = unwrapPlaceholder(c.expression);
-        p.push(new ArgumentMessage(identifier, value));
-      }
+    } else if (t.isExpression(c)) {
+      const [identifier, value] = unwrapPlaceholder(c);
+      p.push(new ArgumentMessage(identifier, value));
     }
 
     return p;
@@ -170,42 +173,45 @@ function findPluralOffset(attributes: t.JSXOpeningElement['attributes']) {
 }
 
 /**
- * Punctuation that never takes a space in front of it. A formatter wrapping
- * long JSX regularly strands these at the start of a line, on their own or
- * ahead of the rest of a clause.
+ * Add text to the message, folding it into the literal in front of it when
+ * there is one, so `Hello{' '}world` is three children in the source and one
+ * run of text in the catalogue.
  */
-const CLOSING_PUNCTUATION = /^[.,;:!?)\]}»”’]/;
+function pushLiteral(messages: Message[], text: string) {
+  if (!text) return;
+
+  const last = messages.at(-1);
+  if (last instanceof LiteralMessage) {
+    messages[messages.length - 1] = new LiteralMessage(last.text + text);
+  } else {
+    messages.push(new LiteralMessage(text));
+  }
+}
 
 /**
- * Collapse the whitespace in a JSX text child the way the source reads.
+ * The text a child renders as, when that is knowable at build time — a text
+ * child, which `buildChildren` has already collapsed into a string, or an
+ * expression holding a literal with nothing interpolated into it.
  *
- * A line break between a word and its neighbour is only how a formatter wrapped
- * a long line, so it still means a space. Dropping it would run the words
- * together — and because ids are content hashes, silently orphan every existing
- * translation for the message.
- *
- * The exception is a line that begins with punctuation, which belongs tight
- * against whatever precedes it. Only an implicit break is treated this way: a
- * space the author wrote on the same line is deliberate and always survives.
+ * The second is what makes `{' '}` the way to write whitespace that has to
+ * survive a line break: it extracts as the space it renders as, rather than as
+ * a placeholder a translator can neither see nor move.
  */
-function normalizeJSXText(value: string, isFirst: boolean, isLast: boolean) {
-  let text = value.replace(/\s+/g, ' ');
-
-  if (isFirst) {
-    text = text.trimStart();
-  } else if (
-    text.startsWith(' ') &&
-    // The leading whitespace spans a line break, so it is the formatter's,
-    // not the author's.
-    /^[^\S\n]*\n/.test(value) &&
-    CLOSING_PUNCTUATION.test(text.slice(1))
-  ) {
-    text = text.slice(1);
+function getExpressionAsLiteralText(expression: t.Node) {
+  if (t.isStringLiteral(expression)) return expression.value;
+  // A number renders as the text `String()` makes of it, and reads as content
+  // in the sentence rather than as a value anything supplies.
+  if (t.isNumericLiteral(expression)) return String(expression.value);
+  // A template literal with nothing interpolated is a string literal written
+  // with different quotes, and renders as one.
+  if (t.isTemplateLiteral(expression) && expression.expressions.length === 0) {
+    const [chunk] = expression.quasis;
+    // Nothing interpolated means exactly one chunk, and a chunk only fails to
+    // cook for an escape that is a syntax error outside a tagged template.
+    /* v8 ignore next */
+    return chunk?.value.cooked ?? '';
   }
-
-  if (isLast) text = text.trimEnd();
-
-  return text;
+  return undefined;
 }
 
 function processJSXOpeningElement(element: t.JSXOpeningElement): [t.Node, string | null] | null {

--- a/packages/transform-jsx/src/whitespace.test.ts
+++ b/packages/transform-jsx/src/whitespace.test.ts
@@ -183,6 +183,16 @@ describe('whitespace written as an expression', () => {
 }`);
   });
 
+  it('extracts a signed number as the text it renders as', () => {
+    expect(extract('<Say>Down {-1} place</Say>')).toBe('Down -1 place');
+  });
+
+  // JSX renders no child for these, which is what makes them the idiom for a
+  // conditional that has nothing to show.
+  it.each([['true'], ['false'], ['null']])('leaves nothing behind for {%s}', (value) => {
+    expect(extract(`<Say>Hello,{${value}} world!</Say>`)).toBe('Hello, world!');
+  });
+
   it('leaves nothing behind for an empty string', () => {
     expect(extract(`<Say>Hello,{''} world!</Say>`)).toBe('Hello, world!');
   });

--- a/packages/transform-jsx/src/whitespace.test.ts
+++ b/packages/transform-jsx/src/whitespace.test.ts
@@ -12,99 +12,61 @@ function extract(jsx: string) {
 }
 
 /**
- * Prettier wraps JSX at the print width, so a translatable line routinely ends
- * with a word and continues with an element on the next line. The line break is
- * the only thing separating them, and it has to keep meaning "space" — dropping
- * it runs the words together and, because ids are content hashes, silently
- * orphans every existing translation for the message.
+ * The whole rule, and the only one worth remembering: a message extracts as the
+ * text JSX renders. A line break and the indentation around it are how the
+ * source is laid out, not part of the sentence, so they never reach a
+ * catalogue — whitespace that has to survive a break is written as `{' '}`.
  *
- * Each case below is lifted from a real example app, named by where it lives.
- * They exist because they are the shapes that regressed in #63 while the whole
- * suite stayed green.
+ * Every case below is what React itself would put on the page for the same JSX.
+ * Where the two could differ, this file is wrong.
  */
-describe('whitespace across a line break', () => {
-  it('joins text to an element on the next line', () => {
-    // examples/react/src/components/board.tsx
+describe('a line break between two children', () => {
+  it('leaves nothing between text and an element on the next line', () => {
     expect(
       extract(`<Say>
-        Nothing here. <a href="#new">Add a task</a> or drag one across from
-        <strong>To do</strong>.
+        <span>{days}</span>
+        d
       </Say>`),
-    ).toBe('Nothing here. <0>Add a task</0> or drag one across from <1>To do</1>.');
+    ).toBe('<0>{days}</0>d');
   });
 
-  it('joins text between two elements that each start a line', () => {
-    // examples/expo/src/habit-card.tsx
+  it('leaves nothing between two elements on their own lines', () => {
     expect(
       extract(`<Say>
-        <Text style={s}>{a}</Text> of
-        <Text style={s}>{b}</Text> this week
+        <strong>1</strong>
+        <em>2</em>
       </Say>`),
-    ).toBe('<0>{a}</0> of <1>{b}</1> this week');
+    ).toBe('<0>1</0><1>2</1>');
   });
 
-  it('joins text to a choice element on both sides', () => {
-    // examples/tanstack-start/src/routes/{-$locale}/index.tsx
+  it('leaves nothing before punctuation stranded on its own line', () => {
+    expect(
+      extract(`<Say>
+        Read <a href="/d">the docs</a>
+        .
+      </Say>`),
+    ).toBe('Read <0>the docs</0>.');
+  });
+
+  it('leaves nothing before a choice element on the next line', () => {
     expect(
       extract(`<Say>
         their
-        <Say.Ordinal _={n} one="#st" two="#nd" few="#rd" other="#th" />
-        time on this stage
+        <Say.Ordinal _={n} one="#st" other="#th" />
       </Say>`),
-    ).toBe(`their {n, selectordinal,
+    ).toBe(`their{n, selectordinal,
   one {#st}
-  two {#nd}
-  few {#rd}
   other {#th}
-} time on this stage`);
-  });
-
-  it('joins text to two consecutive choice elements', () => {
-    // examples/tanstack-start/src/routes/{-$locale}/index.tsx
-    expect(
-      extract(`<Say>
-        The full program —
-        <Say.Plural _={s} one="# session" other="# sessions" />, including
-        <Say.Plural _={w} one="# workshop" other="# workshops" />.
-      </Say>`),
-    ).toBe(`The full program — {s, plural,
-  one {# session}
-  other {# sessions}
-}, including {w, plural,
-  one {# workshop}
-  other {# workshops}
-}.`);
+}`);
   });
 });
 
-describe('whitespace on a single line', () => {
-  it('keeps single spaces around an element', () => {
-    expect(extract('<Say>Hello <strong>brave</strong> world!</Say>')).toBe(
-      'Hello <0>brave</0> world!',
-    );
-  });
-
-  it('collapses a run of spaces to one', () => {
-    expect(extract('<Say>Hello   <strong>brave</strong>   world!</Say>')).toBe(
-      'Hello <0>brave</0> world!',
-    );
-  });
-
-  it('keeps no space where the source has none', () => {
-    expect(extract('<Say>(<strong>brave</strong>)</Say>')).toBe('(<0>brave</0>)');
-  });
-});
-
-describe('whitespace at the container edges', () => {
-  it('trims the indentation a multiline container introduces', () => {
-    expect(
-      extract(`<Say>
-        Hello, world!
-      </Say>`),
-    ).toBe('Hello, world!');
-  });
-
-  it('joins wrapped lines of plain text with a single space', () => {
+/**
+ * The counterpart: a break between two runs of text is the only thing that was
+ * separating the words, so it rejoins as the single space it renders as.
+ */
+describe('a line break inside a run of text', () => {
+  it('joins wrapped lines with a single space', () => {
     expect(
       extract(`<Say>
         Hello,
@@ -113,56 +75,119 @@ describe('whitespace at the container edges', () => {
     ).toBe('Hello, world!');
   });
 
-  it('trims around a leading and trailing element', () => {
+  it('joins lines around a blank line with a single space', () => {
     expect(
       extract(`<Say>
-        <strong>Hello</strong>, world
+        Hello,
+
+        world!
       </Say>`),
-    ).toBe('<0>Hello</0>, world');
+    ).toBe('Hello, world!');
+  });
+
+  it('trims the indentation a multiline container introduces', () => {
+    expect(
+      extract(`<Say>
+        Hello, world!
+      </Say>`),
+    ).toBe('Hello, world!');
+  });
+
+  it('reads a tab as a space', () => {
+    expect(extract('<Say>\n\t\tHello,\n\t\tworld!\n\t</Say>')).toBe('Hello, world!');
   });
 });
 
 /**
- * The counterpart to the block above: a line break usually means a space, but
- * punctuation belongs tight against what precedes it. A formatter wrapping long
- * JSX strands punctuation at the start of a line routinely, and a space in
- * front of it would ship to every locale.
+ * Inside a line there is no break to attribute anything to, so every space is
+ * one the author typed and every one of them renders.
  */
-describe('punctuation at the start of a line', () => {
-  it('takes no space before a full stop left on its own line', () => {
-    expect(
-      extract(`<Say>
-        Kiai Security — only authorize apps you trust. Report malicious
-        integrations in
-        <a href="https://discord.gg/example">our support server</a>
-        .
-      </Say>`),
-    ).toBe(
-      'Kiai Security — only authorize apps you trust. Report malicious integrations in <0>our support server</0>.',
+describe('whitespace written inside a line', () => {
+  it('keeps single spaces around an element', () => {
+    expect(extract('<Say>Hello <strong>brave</strong> world!</Say>')).toBe(
+      'Hello <0>brave</0> world!',
     );
   });
 
-  it('takes no space before a clause that opens with a comma', () => {
-    expect(
-      extract(`<Say>
-        Signed,
-        <strong>the team</strong>
-        , with thanks
-      </Say>`),
-    ).toBe('Signed, <0>the team</0>, with thanks');
+  it('keeps a run of spaces as written', () => {
+    expect(extract('<Say>Hello   <strong>brave</strong>   world!</Say>')).toBe(
+      'Hello   <0>brave</0>   world!',
+    );
   });
 
-  it('keeps a space the author wrote on the same line', () => {
-    // Only an implicit line break is collapsed away; this space is deliberate.
-    expect(extract('<Say>Ready <strong>set</strong> ?</Say>')).toBe('Ready <0>set</0> ?');
+  it('keeps no space where the source has none', () => {
+    expect(extract('<Say>(<strong>brave</strong>)</Say>')).toBe('(<0>brave</0>)');
   });
 
-  it('keeps a space before an opening bracket on the next line', () => {
+  it('keeps a space against the edge of the line the break interrupts', () => {
     expect(
       extract(`<Say>
-        See <a href="/d">the docs</a>
-        (they are short)
+        See <a href="/d">the docs</a> and
+        <a href="/x">the examples</a> too
       </Say>`),
-    ).toBe('See <0>the docs</0> (they are short)');
+    ).toBe('See <0>the docs</0> and<1>the examples</1> too');
+  });
+});
+
+/**
+ * How a space survives a break. Prettier writes `{' '}` itself when it wraps a
+ * line that ends in one, so this is the shape the formatter already produces —
+ * it extracts as the space it renders as, rather than as a placeholder no
+ * translator can see or move.
+ */
+describe('whitespace written as an expression', () => {
+  it("extracts {' '} as a space", () => {
+    expect(
+      extract(`<Say>
+        Nothing here. <a href="#new">Add a task</a> or drag one across from{' '}
+        <strong>To do</strong>.
+      </Say>`),
+    ).toBe('Nothing here. <0>Add a task</0> or drag one across from <1>To do</1>.');
+  });
+
+  it("extracts {'\\n'} as a line break", () => {
+    expect(extract(`<Say>Hello,{'\\n'}world!</Say>`)).toBe('Hello,\nworld!');
+  });
+
+  it('extracts a template literal with nothing interpolated', () => {
+    expect(extract('<Say>Hello,{` `}world!</Say>')).toBe('Hello, world!');
+  });
+
+  it('extracts any other literal string as the text it renders as', () => {
+    expect(extract(`<Say>Hello, {'world'}!</Say>`)).toBe('Hello, world!');
+  });
+
+  // A number written into a sentence is content a translator should be able to
+  // read and move, not a value the catalogue asks the caller for.
+  it('extracts a literal number as the text it renders as', () => {
+    expect(extract('<Say>Top {10} results</Say>')).toBe('Top 10 results');
+  });
+
+  it('folds the surrounding text into a single run', () => {
+    expect(extract(`<Say>Hello,{' '}world!</Say>`)).toBe('Hello, world!');
+  });
+
+  it('carries a space between two choice elements', () => {
+    expect(
+      extract(`<Say>
+        <Say.Plural _={s} one="# session" other="# sessions" />{' '}
+        ·{' '}
+        <Say.Plural _={w} one="# workshop" other="# workshops" />
+      </Say>`),
+    ).toBe(`{s, plural,
+  one {# session}
+  other {# sessions}
+} · {w, plural,
+  one {# workshop}
+  other {# workshops}
+}`);
+  });
+
+  it('leaves nothing behind for an empty string', () => {
+    expect(extract(`<Say>Hello,{''} world!</Say>`)).toBe('Hello, world!');
+  });
+
+  it('still extracts an interpolated value as a placeholder', () => {
+    expect(extract('<Say>Hello, {name}!</Say>')).toBe('Hello, {name}!');
   });
 });

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -367,15 +367,17 @@ Every macro above has a JSX counterpart. The selector is the `_` prop, branches 
 
 ```tsx
 <Say>
-  You have <Say.Number _={items.length} /> items, last updated on
+  You have <Say.Number _={items.length} /> items, last updated on{' '}
   <Say.Date _={{ updatedAt }} style="long" />
 </Say>
 ```
 
-<Callout type="warn">
-  Avoid the `{' '}` spacing escape inside a `<Say>`. It is an expression child like any other, so it
-  extracts as a placeholder (`updated {0} <Say.Date .../>`) and a translator is left moving a stray
-  space around the sentence. Reword so the line break falls where a space belongs.
+<Callout type="info">
+  A message extracts as the text JSX renders, so a line break and the indentation around it are
+  layout and never reach a catalogue. Whitespace that has to survive a break is written as `{' '}` —
+  the same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the
+  space it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is
+  read the same way, as the text it renders as.
 </Callout>
 
 <Callout type="info">


### PR DESCRIPTION
A `<Say>` message now extracts as the text JSX renders, and nothing else. A line break and the indentation around it are how the source is laid out, not part of the sentence, so they disappear — and whitespace that has to survive a break is written as `{' '}`, the same escape Prettier already inserts when it wraps a line ending in a space.

Container children come from `t.react.buildChildren`, so the collapsing rule is the JSX transform's own rather than a heuristic alongside it. The old `normalizeJSXText` guessed: a break meant a space, unless the next line opened with punctuation, in which case it did not. That is right most of the time and wrong the rest, and where it was wrong the catalogue held a sentence the page never showed.

A literal expression child is read as the text it renders as. `{' '}` is a space, `` {`—`} `` is a dash, `{10}` is `10` — each folded into the text around it, so `Hello,{' '}world` is one run in the catalogue rather than a placeholder a translator can neither see nor move. `{...items}` renders an unknown number of unknown things and is ignored.

## Breaking

Any message whose whitespace came from a line break changes, and because ids are content hashes, its id changes with it. The four example apps are updated here with the `{' '}` their rendered output already implied; their catalogues re-extract byte-for-byte identical, so no id in this repo moved.

## Not in scope

`convertMessageToIcu` still trims the finished message, so a `{' '}` at the very start or end of a message is still dropped. Removing that trim lives in `@saykit/config` and changes template-literal messages too — a separate change. Escaping literal braces is likewise left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gi1oKwXNCSoreSAji11AiB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSX text extraction to preserve rendered spacing around inline elements.
  * Correctly handles literal strings, numbers, template literals, punctuation, and whitespace.
  * Ignores spread children during message extraction.

* **Documentation**
  * Updated guidance and examples for explicit JSX whitespace and rendered text extraction.

* **Tests**
  * Expanded coverage for whitespace, literal expressions, punctuation, and adjacent text handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->