### PR TITLE
Accept ICU skeletons as an argument style

### DIFF
--- a/.changeset/tidy-pugs-tickle.md
+++ b/.changeset/tidy-pugs-tickle.md
@@ -1,0 +1,6 @@
+---
+'saykit': minor
+'@saykit/config': minor
+---
+
+Accept ICU skeletons as an argument style, so `{d, date, ::yyyyMMdd}` and `{n, number, ::currency/EUR}` format

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -79,6 +79,8 @@
   },
   "dependencies": {
     "@commander-js/extra-typings": "^15.0.0",
+    "@messageformat/date-skeleton": "2.0.0-0",
+    "@messageformat/number-skeleton": "2.0.0-0",
     "commander": "^15.0.0",
     "js-sha256": "^0.12.0",
     "picomatch": "^4.0.5",

--- a/packages/config/src/features/messages/format.test.ts
+++ b/packages/config/src/features/messages/format.test.ts
@@ -52,8 +52,8 @@ describe('validateArgumentStyle', () => {
     expect(() => validateArgumentStyle('time', 'relative')).toThrow('Invalid time style');
   });
 
-  // MF1 has nowhere to write the currency code, so this formats as a literal
-  // `{$price}`. The literal-pattern escape must not readmit it as a "pattern".
+  // MF1 has nowhere to write the currency code, so this formats as a bare
+  // number. The literal-pattern escape must not readmit it as a "pattern".
   it('rejects the currency style, which the formatter cannot honour', () => {
     expect(() => validateArgumentStyle('number', 'currency')).toThrow('Invalid number style');
     expect(() => validateArgumentStyle('date', 'currency')).toThrow('Invalid date style');
@@ -61,12 +61,51 @@ describe('validateArgumentStyle', () => {
 
   // A pattern is what has a digit placeholder in it; a bare word is a style
   // name, and every style name we do not support has to stay rejected.
-  it.each(['spellout', 'duration', 'compact', 'meduim', '::compact-short'])(
+  it.each(['spellout', 'duration', 'compact', 'meduim'])(
     'rejects the bare word %o as a number pattern',
     (style) => {
       expect(() => validateArgumentStyle('number', style)).toThrow('Invalid number style');
     },
   );
+
+  // A skeleton is the open-ended half of a style, so it is checked by being
+  // resolved rather than by being looked up.
+  it.each([
+    ['number', '::currency/EUR'],
+    ['number', '::compact-short'],
+    ['number', '::percent scale/100'],
+    ['number', '::scale/1000'],
+    ['number', '::.00'],
+    ['date', '::yyyyMMdd'],
+    ['date', '::yMMMM'],
+    ['time', '::Hm'],
+  ] as const)('accepts the %s skeleton %s', (type, style) => {
+    expect(() => validateArgumentStyle(type, style)).not.toThrow();
+  });
+
+  it('rejects a skeleton that names no fields', () => {
+    expect(() => validateArgumentStyle('date', '::')).toThrow(
+      "Invalid date skeleton '::': it names no fields",
+    );
+    // Every token is understood, but a literal shows nothing on its own.
+    expect(() => validateArgumentStyle('date', "::'x'")).toThrow('Invalid date skeleton');
+  });
+
+  it('rejects a skeleton the formatter cannot resolve', () => {
+    expect(() => validateArgumentStyle('number', '::bogus')).toThrow(
+      "Invalid number skeleton '::bogus'",
+    );
+    expect(() => validateArgumentStyle('date', '::qqqq')).toThrow("Invalid date skeleton '::qqqq'");
+  });
+
+  // The named styles are a closed list, so the error names the skeleton escape
+  // too — otherwise an author reading it would think the list was all there is.
+  it('names the skeleton escape for every type', () => {
+    expect(() => validateArgumentStyle('date', 'nope')).toThrow('a skeleton such as ::yyyyMMdd');
+    expect(() => validateArgumentStyle('number', 'nope')).toThrow(
+      'a skeleton such as ::currency/EUR',
+    );
+  });
 
   it('names the literal pattern escape only for numbers', () => {
     expect(() => validateArgumentStyle('number', '#{}')).toThrow('literal number pattern');

--- a/packages/config/src/features/messages/format.test.ts
+++ b/packages/config/src/features/messages/format.test.ts
@@ -98,6 +98,16 @@ describe('validateArgumentStyle', () => {
     expect(() => validateArgumentStyle('date', '::qqqq')).toThrow("Invalid date skeleton '::qqqq'");
   });
 
+  // `qqqq` is valid ICU — a stand-alone quarter — that `Intl` cannot show. A
+  // skeleton naming it alongside fields that do resolve is still rejected, so
+  // this agrees with the runtime rather than letting a field be dropped.
+  it('rejects a skeleton that only partly resolves', () => {
+    expect(() => validateArgumentStyle('date', '::yMMMdqqqq')).toThrow(
+      "Invalid date skeleton '::yMMMdqqqq'",
+    );
+    expect(() => validateArgumentStyle('date', "::yMMMd'x'")).toThrow('Invalid date skeleton');
+  });
+
   // The named styles are a closed list, so the error names the skeleton escape
   // too — otherwise an author reading it would think the list was all there is.
   it('names the skeleton escape for every type', () => {

--- a/packages/config/src/features/messages/format.ts
+++ b/packages/config/src/features/messages/format.ts
@@ -1,11 +1,17 @@
+import { getDateTimeFormatOptions, parseDateTokens } from '@messageformat/date-skeleton';
+import { getNumberFormatOptions, parseNumberSkeleton } from '@messageformat/number-skeleton';
+
 /**
  * The ICU argument types a macro can author, and the named styles each accepts.
  *
+ * A style may also be a skeleton, which is where the formats these names have
+ * no word for live — see {@link validateArgumentStyle}.
+ *
  * `currency` is deliberately absent from `number`. MF1 has nowhere to write the
  * currency code — it comes from the formatter's configuration, not the message
- * — so `{price, number, currency}` formats as a literal `{$price}` at runtime
- * rather than an amount. Currency belongs to number skeletons, which the
- * formatter does not accept yet either.
+ * — so `{price, number, currency}` formats as a bare number at runtime rather
+ * than an amount. Currency belongs to a skeleton, `::currency/EUR`, which names
+ * the code and which the formatter does honour.
  *
  * `spellout`, RBNF `ordinal`, and `choice` are absent by decision rather than
  * oversight: the first two are ICU4J/ICU4C rule-based formats with no `Intl`
@@ -42,6 +48,50 @@ export function isArgumentType(kind: string): kind is ArgumentType {
 const LITERAL_STYLE_PATTERN = /^[^{}\r\n]*[#0][^{}\r\n]*$/;
 
 /**
+ * An ICU skeleton: a `::`-prefixed description of the parts a value is written
+ * with, rather than a name for a whole format.
+ */
+const SKELETON = '::';
+
+/**
+ * Check a skeleton by resolving it, and report what stopped it resolving.
+ *
+ * A skeleton is the open-ended half of a style, so unlike a named style it
+ * cannot be checked against a list. It can be checked by doing the work: the
+ * parsers below are the same ones the runtime formats with, and a skeleton that
+ * yields no options here is one that would format as nothing there.
+ *
+ * The runtime resolves the same skeletons in `saykit`'s
+ * `messageformat/styles.ts` and falls back to a default format when one does
+ * not resolve. This is the check that means an author sees the problem first,
+ * with a file and a line, rather than a reader seeing the wrong date.
+ *
+ * @returns The reason the skeleton is invalid, or `undefined` if it is valid
+ */
+function invalidSkeleton(type: ArgumentType, skeleton: string): string | undefined {
+  if (skeleton === '') return 'it names no fields';
+
+  const errors: string[] = [];
+
+  if (type === 'number') {
+    const parsed = parseNumberSkeleton(skeleton, (error) => errors.push(String(error)));
+    // `scale` is a multiplier rather than a formatting option, so the runtime
+    // applies it itself; it is reported here but is not an error.
+    getNumberFormatOptions(parsed, (stem) => {
+      if (stem !== 'scale') errors.push(`unsupported stem '${stem}'`);
+    });
+    return errors[0];
+  }
+
+  const tokens = parseDateTokens(skeleton);
+  const options = getDateTimeFormatOptions(tokens, (_type, message) => errors.push(message));
+  if (errors.length > 0) return errors[0];
+  // Every token was understood but none of them named a field `Intl` can show.
+  if (Object.keys(options).length === 0) return 'it names no fields';
+  return undefined;
+}
+
+/**
  * Reject an argument style the formatter cannot honour, while the style is
  * still attached to a file and a line.
  *
@@ -49,10 +99,19 @@ const LITERAL_STYLE_PATTERN = /^[^{}\r\n]*[#0][^{}\r\n]*$/;
  * nothing between here and the runtime has an opinion about it. Left unchecked,
  * a typo like `{d, date, meduim}` extracts to a catalogue entry that looks
  * perfectly normal and only misformats once it reaches a user.
+ *
+ * Three forms are accepted: a named style, a `::`-prefixed skeleton, and — for
+ * a number — a literal pattern such as `#,##0.00`.
  */
 export function validateArgumentStyle(type: ArgumentType, style: string) {
   const named: readonly string[] = ARGUMENT_STYLES[type];
   if (named.includes(style)) return;
+
+  if (style.startsWith(SKELETON)) {
+    const reason = invalidSkeleton(type, style.slice(SKELETON.length));
+    if (!reason) return;
+    throw new Error(`Invalid ${type} skeleton '${style}': ${reason}`);
+  }
 
   // A number's style may also be a literal pattern, which is open-ended and so
   // can only be checked for the syntax it would break.
@@ -60,7 +119,8 @@ export function validateArgumentStyle(type: ArgumentType, style: string) {
 
   const expected = named.map((s) => `'${s}'`).join(', ');
   throw new Error(
-    `Invalid ${type} style '${style}', expected ${expected}` +
+    `Invalid ${type} style '${style}', expected ${expected}, or a skeleton such as ` +
+      (type === 'number' ? '::currency/EUR' : '::yyyyMMdd') +
       (type === 'number' ? ', or a literal number pattern such as #,##0.00' : ''),
   );
 }

--- a/packages/integration-react/src/runtime/index.ts
+++ b/packages/integration-react/src/runtime/index.ts
@@ -155,10 +155,12 @@ export namespace Say {
    * ```tsx
    * <Say>You have <Say.Number _={items.length} /> items</Say>
    * <Say>Battery at <Say.Number _={level} style="percent" /></Say>
+   * <Say>Total <Say.Number _={total} style="::currency/EUR" /></Say>
    * ```
    *
    * @param props._ Number to format
-   * @param props.style Formatting style, either a named style or a literal number pattern
+   * @param props.style Formatting style: a named style, an ICU skeleton such as
+   *   `::currency/EUR`, or a literal number pattern such as `#,##0.00`
    * @returns The formatted number, as a React node
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
@@ -175,10 +177,12 @@ export namespace Say {
    * @example
    * ```tsx
    * <Say>Published <Say.Date _={post.publishedAt} style="medium" /></Say>
+   * <Say>Published <Say.Date _={post.publishedAt} style="::yMMMM" /></Say>
    * ```
    *
    * @param props._ Date to format
-   * @param props.style Formatting style
+   * @param props.style Formatting style, either a named style or an ICU
+   *   skeleton such as `::yyyyMMdd`
    * @returns The formatted date, as a React node
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
@@ -198,10 +202,12 @@ export namespace Say {
    * @example
    * ```tsx
    * <Say>Doors open at <Say.Time _={opensAt} style="short" /></Say>
+   * <Say>Doors open at <Say.Time _={opensAt} style="::Hm" /></Say>
    * ```
    *
    * @param props._ Date to format
-   * @param props.style Formatting style
+   * @param props.style Formatting style, either a named style or an ICU
+   *   skeleton such as `::Hm`
    * @returns The formatted time, as a React node
    * @remark This is a macro and must be used with the relevant saykit plugin
    */

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -41,6 +41,9 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
-    "@messageformat/icu-messageformat-1": "^0.12.0"
+    "@messageformat/date-skeleton": "2.0.0-0",
+    "@messageformat/number-skeleton": "2.0.0-0",
+    "@messageformat/parser": "^5.1.1",
+    "messageformat": "^4.0.0"
   }
 }

--- a/packages/integration/src/messageformat/convert.ts
+++ b/packages/integration/src/messageformat/convert.ts
@@ -198,11 +198,12 @@ function declaration({ arg, name, type, offset }: Selector): Model.Declaration {
  * ordering is what makes `=1` beat `one` and `one` beat `other`.
  */
 function sortKeys(keys: (string | number)[]) {
-  return Array.from(new Set(keys)).sort((a, b) => {
-    if (typeof a === 'number' || b === 'other') return -1;
-    if (typeof b === 'number' || a === 'other') return 1;
-    return 0;
-  });
+  // Ranked rather than compared pairwise, so the order is total: comparing two
+  // exact numbers by the rules alone answers `-1` whichever way round they are
+  // asked, which is not an ordering and would leave anything that later depends
+  // on it reading an arbitrary one.
+  const rank = (key: string | number) => (typeof key === 'number' ? 0 : key === 'other' ? 2 : 1);
+  return Array.from(new Set(keys)).sort((a, b) => rank(a) - rank(b));
 }
 
 /**

--- a/packages/integration/src/messageformat/convert.ts
+++ b/packages/integration/src/messageformat/convert.ts
@@ -1,0 +1,294 @@
+import type { Content, FunctionArg, Octothorpe, PlainArg, Select } from '@messageformat/parser';
+import type { Model } from 'messageformat';
+import { literal } from './options.js';
+import { dateTimeStyle, numberStyle, StyleError } from './styles.js';
+
+/**
+ * The MF1 syntax tree, rewritten as an MF2 message.
+ *
+ * The two disagree about where a choice may appear. MF1 nests selects freely,
+ * anywhere a character can go; MF2 has exactly one `.match` at the top of a
+ * message, with one key per selector. Most of this module is that
+ * reconciliation — every selector in the tree is lifted to the top, and the
+ * message body is rewritten once per combination of their cases.
+ *
+ * Adapted from `@messageformat/icu-messageformat-1` (Apache-2.0), which solves
+ * the same problem the same way.
+ */
+
+export type Token = Content | PlainArg | FunctionArg | Select | Octothorpe;
+
+const isSelect = (token: Token): token is Select =>
+  token.type === 'plural' || token.type === 'select' || token.type === 'selectordinal';
+
+/** `=3` names the number three; anything else names a CLDR category. */
+const asKey = (key: string) => (/^=\d+$/.test(key) ? Number(key.slice(1)) : key);
+
+/**
+ * Build the expression for a `{arg, type, style}` placeholder.
+ *
+ * A style the conversion cannot read does not fail the message: the argument
+ * falls back to its bare formatter, so `{n, number, bogus}` still writes a
+ * number and `{d, date, bogus}` still writes a date. A message is authored once
+ * and read by everyone, and one that renders in a slightly wrong shape beats
+ * one that renders `{$n}`.
+ */
+function functionRef(token: FunctionArg): Model.FunctionRef {
+  let style = '';
+  for (const part of token.param ?? []) {
+    // Only literal text can be read at compile time; a placeholder nested inside
+    // a style has no value yet, and MF2 has no way to defer one.
+    if (part.type !== 'content') throw new Error(`Unsupported style part: ${part.type}`);
+    style += part.value;
+  }
+  style = style.trim();
+
+  const ref = (name: string, value?: unknown): Model.FunctionRef => ({
+    type: 'function',
+    name,
+    ...(value === undefined ? {} : { options: { options: literal(value) } }),
+  });
+
+  try {
+    switch (token.key) {
+      case 'date':
+      case 'time':
+        return ref('say:datetime', dateTimeStyle(token.key, style));
+      case 'number':
+        return ref('say:number', numberStyle(style));
+      case 'duration':
+        return ref('say:duration');
+      default:
+        throw new StyleError(`Unsupported argument type ${token.key}`);
+    }
+  } catch (error) {
+    // Only a style is recovered from. Nothing else in the `try` throws today,
+    // so this is a guard against a parser one day doing so rather than a path
+    // taken, and a bug in one must not be swallowed as a bad style.
+    /* v8 ignore next */
+    if (!(error instanceof StyleError)) throw error;
+    switch (token.key) {
+      case 'date':
+      case 'time':
+        return ref('say:datetime', dateTimeStyle(token.key, ''));
+      case 'number':
+        return ref('say:number', {});
+      default:
+        return ref('say:string');
+    }
+  }
+}
+
+/**
+ * Convert one MF1 token into an MF2 pattern part.
+ *
+ * @param plural The argument a `#` in scope refers to, if any
+ */
+function toPart(token: Token, plural: string | null): Model.Expression | string {
+  switch (token.type) {
+    case 'content':
+      return token.value;
+    case 'argument':
+      return { type: 'expression', arg: { type: 'variable', name: token.arg } };
+    case 'function':
+      return {
+        type: 'expression',
+        arg: { type: 'variable', name: token.arg },
+        functionRef: functionRef(token),
+      };
+    case 'octothorpe':
+      // The parser only makes a `#` a token when a plural encloses it — `#`
+      // anywhere else is content by the time it reaches us — so the text case
+      // is a guard rather than a path.
+      /* v8 ignore next */
+      return plural ? { type: 'expression', arg: { type: 'variable', name: plural } } : '#';
+    /* v8 ignore next 2 -- the token union has no other members */
+    default:
+      throw new Error(`Unsupported token type: ${(token as Token).type}`);
+  }
+}
+
+type Selector = {
+  arg: string;
+  /**
+   * The variable this selector reads, which is `arg` for the first selector on
+   * an argument and a generated name for any later one. MF2 allows a name to be
+   * declared once, so two selects asking different questions of one argument —
+   * the same `{n, plural}` at two offsets — need two names to live under. The
+   * `#` a generated name cannot appear in an MF1 argument name, so one can
+   * never collide with a name the message itself uses.
+   */
+  name: string;
+  type: Select['type'];
+  offset: number;
+  keys: (string | number)[];
+};
+
+/**
+ * Two selects are the same selector when they ask the same question of the same
+ * argument. Their keys then merge into one dimension rather than multiplying
+ * into two, which keeps `{n, plural, ...}` repeated in several branches from
+ * squaring the number of variants.
+ */
+const sameSelector = (a: Pick<Selector, 'arg' | 'type' | 'offset'>) => (b: Selector) =>
+  a.arg === b.arg && a.type === b.type && a.offset === b.offset;
+
+/** Collect every selector in the message, at any depth, outermost first. */
+function findSelectors(tokens: Token[]) {
+  const selectors: Selector[] = [];
+
+  const add = (selector: Omit<Selector, 'name'>) => {
+    const existing = selectors.find(sameSelector(selector));
+    if (existing) {
+      existing.keys.push(...selector.keys);
+      return;
+    }
+    // The first selector on an argument reads the argument itself; a second
+    // question about the same one needs somewhere else to live.
+    const taken = selectors.filter((s) => s.arg === selector.arg).length;
+    const name = taken === 0 ? selector.arg : `${selector.arg}#${taken}`;
+    selectors.push({ ...selector, name });
+  };
+
+  for (const token of tokens) {
+    if (!isSelect(token)) continue;
+    add({
+      arg: token.arg,
+      type: token.type,
+      offset: token.pluralOffset ?? 0,
+      keys: token.cases.map((c) => (token.type === 'select' ? c.key : asKey(c.key))),
+    });
+    for (const c of token.cases) for (const inner of findSelectors(c.tokens)) add(inner);
+  }
+
+  return selectors;
+}
+
+/**
+ * The declaration binding a selector's name to the function that selects on it
+ * — `say:string` for a `select`, `say:plural` otherwise.
+ *
+ * The first selector on an argument declares the argument itself, so that a
+ * plain `{n}` elsewhere in the message and a `#` inside a branch both resolve
+ * to the selected value. A later one declares a name of its own, reading the
+ * argument a second time.
+ */
+function declaration({ arg, name, type, offset }: Selector): Model.Declaration {
+  const functionRef: Model.FunctionRef =
+    type === 'select'
+      ? { type: 'function', name: 'say:string' }
+      : {
+          type: 'function',
+          name: 'say:plural',
+          options: { options: literal({ offset, ordinal: type === 'selectordinal' }) },
+        };
+
+  const value: Model.Expression = {
+    type: 'expression',
+    arg: { type: 'variable', name: arg },
+    functionRef,
+  };
+
+  return name === arg ? { type: 'input', name, value } : { type: 'local', name, value };
+}
+
+/**
+ * Order a selector's keys so exact numbers come before categories and `other`
+ * comes last. MF2 takes the first variant whose keys all match, so this
+ * ordering is what makes `=1` beat `one` and `one` beat `other`.
+ */
+function sortKeys(keys: (string | number)[]) {
+  return Array.from(new Set(keys)).sort((a, b) => {
+    if (typeof a === 'number' || b === 'other') return -1;
+    if (typeof b === 'number' || a === 'other') return 1;
+    return 0;
+  });
+}
+
+/**
+ * Convert a parsed MF1 message into an MF2 message.
+ *
+ * With no selectors this is a straight token-by-token walk. With any, the
+ * message becomes a `select` whose variants are every combination of every
+ * selector's keys, and each token is written into every variant the cases
+ * enclosing it admit. That is the flattening: a token inside `one` lands in all
+ * the variants keyed `one`, and a token outside every select lands in all of
+ * them.
+ */
+export function toMessage(ast: Token[]): Model.Message {
+  const selectors = findSelectors(ast);
+
+  if (selectors.length === 0) {
+    return { type: 'message', declarations: [], pattern: ast.map((t) => toPart(t, null)) };
+  }
+
+  // Build the key tuples first, then fill in their patterns below.
+  let tuples: (string | number)[][] = [[]];
+  for (const selector of selectors) {
+    const keys = sortKeys(selector.keys);
+    tuples = tuples.flatMap((tuple) => keys.map((key) => [...tuple, key]));
+  }
+
+  const variants: Model.Variant[] = tuples.map((tuple) => ({
+    keys: tuple.map((key) =>
+      key === 'other' ? { type: '*' } : { type: 'literal', quoted: false, value: String(key) },
+    ),
+    value: [],
+  }));
+
+  /**
+   * Walk the tokens, appending each to the variants still in play.
+   *
+   * @param plural The argument a `#` in scope refers to, if any
+   * @param filter The case chosen so far in each select already entered
+   */
+  function fill(
+    tokens: Token[],
+    plural: string | null,
+    filter: { index: number; key: string | number }[],
+  ) {
+    for (const token of tokens) {
+      if (isSelect(token)) {
+        const index = selectors.findIndex(
+          sameSelector({ arg: token.arg, type: token.type, offset: token.pluralOffset ?? 0 }),
+        );
+        // A `#` inside a `select` still refers to the plural enclosing it, and
+        // inside a plural it refers to that plural's own name — which is not
+        // the argument's when the same argument is selected twice.
+        const inner = token.type === 'select' ? plural : selectors[index]!.name;
+        for (const c of token.cases) {
+          const key = token.type === 'select' ? c.key : asKey(c.key);
+          fill(c.tokens, inner, [...filter, { index, key }]);
+        }
+        continue;
+      }
+
+      for (const variant of variants) {
+        const matches = filter.every(({ index, key }) => {
+          const vk = variant.keys[index]!;
+          return vk.type === '*' ? key === 'other' : String(key) === vk.value;
+        });
+        if (!matches) continue;
+
+        const part = toPart(token, plural);
+        const last = variant.value.length - 1;
+        // Adjacent text merges, so a variant reads as one string rather than a
+        // run of fragments split where the cases it came from began and ended.
+        if (typeof part === 'string' && typeof variant.value[last] === 'string') {
+          variant.value[last] += part;
+        } else {
+          variant.value.push(part);
+        }
+      }
+    }
+  }
+
+  fill(ast, null, []);
+
+  return {
+    type: 'select',
+    declarations: selectors.map(declaration),
+    selectors: selectors.map((s) => ({ type: 'variable', name: s.name })),
+    variants,
+  };
+}

--- a/packages/integration/src/messageformat/functions.ts
+++ b/packages/integration/src/messageformat/functions.ts
@@ -1,0 +1,77 @@
+import type { MessageFunction } from 'messageformat/functions';
+import { options, type NumberOptions, type PluralOptions } from './options.js';
+import { duration, datetime, number, numeric, temporal } from './values.js';
+
+/**
+ * The handlers a compiled message resolves against.
+ *
+ * Every placeholder the conversion emits names one of these, and each takes its
+ * whole configuration as a single already-resolved bag. A handler is therefore
+ * only ever the last step — coerce the operand, apply the scale, call `Intl` —
+ * and the work of reading a style stays in `styles.ts`, where it happens once
+ * per message rather than once per format.
+ */
+export const functions = {
+  'say:number': (ctx, opt, operand) => {
+    const { scale, ...nf } = options<NumberOptions>(opt.options);
+    const value = numeric(operand);
+    return number(ctx.locales as string[], scale ? Number(value) * scale : value, nf);
+  },
+
+  'say:datetime': (ctx, opt, operand) =>
+    datetime(ctx.locales as string[], temporal(operand), options(opt.options)),
+
+  'say:duration': (_ctx, _opt, operand) => {
+    const value = Number(numeric(operand));
+    const str = duration(value);
+    return {
+      type: 'say:duration',
+      toParts: () => [{ type: 'say:duration', value: str }],
+      toString: () => str,
+      valueOf: () => value,
+    };
+  },
+
+  /**
+   * The selector behind `plural` and `selectordinal`.
+   *
+   * An exact `=n` case is matched against the number as written, before the
+   * offset, so `=1` still means one. The category is chosen from the offset
+   * number instead — which is what lets "You and 2 others" branch on a total of
+   * three — and that same offset number is what a `#` in the branch prints.
+   */
+  'say:plural': (ctx, opt, operand) => {
+    const { offset = 0, ordinal = false } = options<PluralOptions>(opt.options);
+    const value = numeric(operand);
+    const shifted = typeof value === 'bigint' ? value - BigInt(offset) : value - offset;
+
+    const result = number(ctx.locales as string[], shifted, {});
+    // The offset number is what `#` prints, but the original is what the value
+    // *is* — so a second selector reading this one offsets from the number the
+    // message was given rather than from an already-shifted one.
+    result.valueOf = () => value;
+    result.selectKey = (keys) => {
+      const exact = String(value);
+      if (keys.has(exact)) return exact;
+      // `Intl.PluralRules` takes a number, never a bigint.
+      const category = new Intl.PluralRules(ctx.locales as string[], {
+        localeMatcher: ctx.localeMatcher,
+        type: ordinal ? 'ordinal' : 'cardinal',
+      }).select(Number(shifted));
+      return keys.has(category) ? category : null;
+    };
+    return result;
+  },
+
+  /** The selector behind `select`, and the fallback for an argument type we do not know. */
+  'say:string': (_ctx, _opt, operand) => {
+    const str = operand === undefined ? '' : String(operand);
+    return {
+      type: 'string',
+      selectKey: (keys) => (keys.has(str) ? str : null),
+      toParts: () => [{ type: 'string', value: str }],
+      toString: () => str,
+      valueOf: () => str,
+    };
+  },
+} satisfies Record<string, MessageFunction<string, string>>;

--- a/packages/integration/src/messageformat/functions.ts
+++ b/packages/integration/src/messageformat/functions.ts
@@ -50,14 +50,20 @@ export const functions = {
     // *is* — so a second selector reading this one offsets from the number the
     // message was given rather than from an already-shifted one.
     result.valueOf = () => value;
+
+    // Built once and kept, like the formatters in `values.ts`: the locale and
+    // the rule type are fixed for the placeholder, and constructing an `Intl`
+    // object is the expensive half of selecting.
+    let rules: Intl.PluralRules | undefined;
     result.selectKey = (keys) => {
       const exact = String(value);
       if (keys.has(exact)) return exact;
-      // `Intl.PluralRules` takes a number, never a bigint.
-      const category = new Intl.PluralRules(ctx.locales as string[], {
+      rules ??= new Intl.PluralRules(ctx.locales as string[], {
         localeMatcher: ctx.localeMatcher,
         type: ordinal ? 'ordinal' : 'cardinal',
-      }).select(Number(shifted));
+      });
+      // `Intl.PluralRules` takes a number, never a bigint.
+      const category = rules.select(Number(shifted));
       return keys.has(category) ? category : null;
     };
     return result;

--- a/packages/integration/src/messageformat/index.test.ts
+++ b/packages/integration/src/messageformat/index.test.ts
@@ -46,7 +46,7 @@ describe('operands', () => {
 
   // `undefined` is a missing value rather than a bad one, and MF2 reports the
   // missing variable itself.
-  it('treats a missing number as zero rather than an error', () => {
+  it('treats a missing number as NaN rather than an error', () => {
     expect(numeric(undefined)).toBeNaN();
   });
 
@@ -187,6 +187,21 @@ describe('styles', () => {
   it('falls back for an empty skeleton', () => {
     expect(format('{d, date, ::}', { d: when })).toBe('Jan 2, 2020');
   });
+
+  // `qqqq` is valid ICU — a stand-alone quarter — that `Intl` cannot show.
+  // Keeping the fields that did resolve would render a date the message never
+  // asked for, so one unshowable field fails the whole skeleton.
+  it('falls back rather than dropping a field it cannot show', () => {
+    expect(format('{d, date, ::yMMMdqqqq}', { d: when })).toBe('Jan 2, 2020');
+    expect(format("{d, date, ::yMMMd'x'}", { d: when })).toBe('Jan 2, 2020');
+  });
+
+  // The styles come from a plain object, so a key every object inherits must
+  // not pass for one an author asked for.
+  it('rejects an inherited property name as a style', () => {
+    expect(format('{d, date, toString}', { d: when })).toBe('Jan 2, 2020');
+    expect(format('{d, date, constructor}', { d: when })).toBe('Jan 2, 2020');
+  });
 });
 
 /**
@@ -241,6 +256,18 @@ describe('duration', () => {
     [3600, '1:00:00'],
     [359999, '99:59:59'],
   ])('formats %o', (seconds, expected) => {
+    expect(duration(seconds)).toBe(expected);
+  });
+
+  // Seconds are rounded to the millisecond, and a value that rounds up to a
+  // whole minute has to carry rather than be written as `:60`.
+  it.each([
+    [59.9999, '1:00'],
+    [119.9999, '2:00'],
+    [3599.9999, '1:00:00'],
+    [59.5, '0:59.500'],
+    [59.4994, '0:59.499'],
+  ])('carries a rounded second in %o', (seconds, expected) => {
     expect(duration(seconds)).toBe(expected);
   });
 });

--- a/packages/integration/src/messageformat/index.test.ts
+++ b/packages/integration/src/messageformat/index.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import { functions } from './functions.js';
+import { options } from './options.js';
+import { duration, numeric, temporal } from './values.js';
+import { compile } from './index.js';
+
+/**
+ * `Say.call` only ever asks a message for a string, so the parts side of every
+ * value — and the operand coercions a hand-written catalogue can reach that the
+ * macros cannot author — are exercised here against `compile` directly.
+ */
+
+const when = new Date(2020, 0, 2, 12, 4, 5);
+
+/** Format, failing on the errors `MessageFormat` would otherwise only warn about. */
+function format(message: string, values: Record<string, unknown> = {}) {
+  const errors: unknown[] = [];
+  const result = compile('en-US', message).format(values, (e) => errors.push(e));
+  if (errors.length > 0) throw errors[0];
+  return result.replaceAll(/[⁨⁩]/g, '');
+}
+
+function parts(message: string, values: Record<string, unknown> = {}) {
+  return compile('en-US', message).formatToParts(values, (e) => {
+    throw e;
+  });
+}
+
+describe('operands', () => {
+  it('reads a number written as a string or a wrapper', () => {
+    expect(numeric('42')).toBe(42);
+    expect(numeric({ valueOf: () => 42 })).toBe(42);
+  });
+
+  // A bigint is passed through rather than narrowed, since the precision is the
+  // whole point of writing one.
+  it('keeps a bigint a bigint', () => {
+    expect(numeric(10n ** 25n)).toBe(10n ** 25n);
+    expect(format('{n, number}', { n: 10n ** 25n })).toBe('10,000,000,000,000,000,000,000,000');
+  });
+
+  it('throws for a value that is not a number', () => {
+    expect(() => numeric('nope')).toThrow('Input is not numeric');
+    expect(() => format('{n, number}', { n: 'nope' })).toThrow('Input is not numeric');
+  });
+
+  // `undefined` is a missing value rather than a bad one, and MF2 reports the
+  // missing variable itself.
+  it('treats a missing number as zero rather than an error', () => {
+    expect(numeric(undefined)).toBeNaN();
+  });
+
+  it.each([
+    ['a Date', when],
+    ['an epoch offset', when.getTime()],
+    ['a parseable string', when.toISOString()],
+    ['a wrapper', { valueOf: () => when.getTime() }],
+  ])('reads a date written as %s', (_form, value) => {
+    expect(temporal(value).getTime()).toBe(when.getTime());
+    expect(format('{d, date, short}', { d: value })).toBe('1/2/2020');
+  });
+
+  it('throws for a value that is not a date', () => {
+    expect(() => temporal('nope')).toThrow('Input is not a valid date');
+    expect(() => temporal(null)).toThrow('Input is not a valid date');
+    expect(() => format('{d, date}', { d: 'nope' })).toThrow('Input is not a valid date');
+  });
+});
+
+describe('formatted parts', () => {
+  it.each([
+    ['{n, number, ::currency/EUR}', { n: 1234.5 }, 'number'],
+    ['{d, date, ::yyyyMMdd}', { d: when }, 'datetime'],
+  ])('reports %s as %s parts', (message, values, type) => {
+    const [part] = parts(message, values) as [
+      { type: string; locale: string; dir?: string; parts: unknown[] },
+    ];
+    expect(part.type).toBe(type);
+    expect(part.locale).toBe('en-US');
+    // The direction is a lazy getter off the resolved locale, and bidi
+    // isolation is what asks for it.
+    expect(part.dir).toBe('ltr');
+    expect(part.parts.length).toBeGreaterThan(0);
+  });
+
+  it('reports a duration as one part', () => {
+    expect(parts('{n, duration}', { n: 61 })).toContainEqual(
+      expect.objectContaining({ type: 'say:duration', value: '1:01' }),
+    );
+  });
+
+  it('reports an unknown argument type as a string part', () => {
+    expect(parts('{n, spellout}', { n: 42 })).toContainEqual(
+      expect.objectContaining({ type: 'string', value: '42' }),
+    );
+  });
+
+  it('reports a selector as a number part', () => {
+    expect(parts('{n, plural, other {#}}', { n: 3 })).toContainEqual(
+      expect.objectContaining({ type: 'number' }),
+    );
+  });
+});
+
+describe('selectors', () => {
+  // Two selects asking the same question of the same argument are one selector.
+  // Were they two, the variants would square rather than merge.
+  it('merges repeated selects on the same argument', () => {
+    const message =
+      '{n, plural, one {{g, select, f {her} other {their}} item}' +
+      ' other {{n, plural, one {x} other {# items}}}}';
+    expect(format(message, { n: 1, g: 'f' })).toBe('her item');
+    expect(format(message, { n: 3, g: 'm' })).toBe('3 items');
+  });
+
+  // Same argument, different offset, is a different question and so stays a
+  // separate selector.
+  it('keeps selects with different offsets apart', () => {
+    const message = '{n, plural, offset:1 one {A#} other {{n, plural, one {B#} other {C#}}}}';
+    expect(format(message, { n: 2 })).toBe('A1');
+    expect(format(message, { n: 5 })).toBe('C5');
+  });
+
+  it('orders exact numbers before categories and other last', () => {
+    const message = '{n, plural, other {many} one {a} =1 {exactly one} =0 {none}}';
+    expect(format(message, { n: 0 })).toBe('none');
+    expect(format(message, { n: 1 })).toBe('exactly one');
+    expect(format(message, { n: 7 })).toBe('many');
+  });
+
+  it('selects an ordinal category', () => {
+    const message = '{n, selectordinal, one {#st} two {#nd} few {#rd} other {#th}}';
+    expect(format(message, { n: 1 })).toBe('1st');
+    expect(format(message, { n: 22 })).toBe('22nd');
+    expect(format(message, { n: 11 })).toBe('11th');
+  });
+
+  it('offsets a bigint selector', () => {
+    const message = '{n, plural, offset:1 one {# other} other {# others}}';
+    expect(format(message, { n: 3n })).toBe('2 others');
+  });
+
+  it('falls through to other when no category matches', () => {
+    expect(format('{g, select, f {her} other {their}}', { g: 'nope' })).toBe('their');
+  });
+
+  // A `#` inside a nested `select` still counts the plural enclosing it.
+  it('resolves a hash inside a select to the enclosing plural', () => {
+    const message = '{n, plural, other {{g, select, other {# of them}}}}';
+    expect(format(message, { n: 4, g: 'x' })).toBe('4 of them');
+  });
+
+  // Outside a plural there is nothing to substitute.
+  it('writes a hash outside a plural as text', () => {
+    expect(format('a # b')).toBe('a # b');
+    expect(format('{g, select, other {#}}', { g: 'x' })).toBe('#');
+  });
+
+  // Two placeholders running together leave no text between them to merge into.
+  it('keeps adjacent placeholders separate within a variant', () => {
+    expect(format('{n, plural, other {{a}{b}}}', { n: 1, a: 'x', b: 'y' })).toBe('xy');
+  });
+});
+
+describe('styles', () => {
+  it('rejects a style containing a placeholder', () => {
+    // Nothing can resolve `{x}` while the message is being compiled, and MF2
+    // has no way to defer it.
+    expect(() => compile('en-US', '{d, date, {x}}')).toThrow('Unsupported style part: argument');
+  });
+
+  // `XXX` is ISO 4217's "no currency", which is what a pattern naming a
+  // currency it has no code for should format as. `Intl` gives it the two
+  // fraction digits a currency carries.
+  it('reads a currency out of a literal pattern', () => {
+    // `Intl` separates a currency code from its amount with a non-breaking
+    // space, which is a detail of the locale rather than of the conversion.
+    expect(format('{n, number, ¤¤#0}', { n: 12 }).replace(' ', ' ')).toBe('XXX 12.00');
+  });
+
+  it('falls back for a pattern asking for something Intl cannot express', () => {
+    expect(format('{n, number, #E0}', { n: 1234.5 })).toBe('1,234.5');
+  });
+
+  // Every token parsed, there were simply none of them. There is no error to
+  // report, so the skeleton is described rather than quoted back.
+  it('falls back for an empty skeleton', () => {
+    expect(format('{d, date, ::}', { d: when })).toBe('Jan 2, 2020');
+  });
+});
+
+/**
+ * A value's `valueOf` is only read when it becomes the operand of another
+ * function, which no MF1 message can ask for — a duration or a string is always
+ * the end of the line. They are called here directly so the contract they
+ * publish is the one they keep.
+ */
+describe('message values', () => {
+  const ctx = { locales: ['en-US'], localeMatcher: 'best fit' } as never;
+
+  it('reports a duration as the seconds it was given', () => {
+    expect(functions['say:duration'](ctx, {}, 61).valueOf()).toBe(61);
+  });
+
+  it('reports a number as the number it formatted', () => {
+    expect(functions['say:number'](ctx, {}, 1234.5).valueOf!()).toBe(1234.5);
+    // The scale is part of the value, not of the way it is written.
+    expect(functions['say:number'](ctx, { options: { scale: 1000 } }, 1.5).valueOf!()).toBe(1500);
+  });
+
+  it('reports a date as a Date', () => {
+    expect(functions['say:datetime'](ctx, {}, when).valueOf!()).toStrictEqual(when);
+  });
+
+  // A plural reports the number the message was given, not the offset one it
+  // prints — which is what lets a second selector offset from the right place.
+  it('reports a plural as the number before its offset', () => {
+    const value = functions['say:plural'](ctx, { options: { offset: 1 } }, 3);
+    expect(value.valueOf!()).toBe(3);
+    expect(value.toString!()).toBe('2');
+  });
+
+  it('reports a string as itself', () => {
+    expect(functions['say:string'](ctx, {}, 'x').valueOf()).toBe('x');
+  });
+
+  // A `select` on a value the caller never passed still has to choose a branch,
+  // and `other` is the branch that takes it.
+  it('reads a missing string as empty', () => {
+    const value = functions['say:string'](ctx, {}, undefined);
+    expect(value.toString()).toBe('');
+    expect(value.selectKey(new Set(['a']))).toBeNull();
+    expect(value.selectKey(new Set(['']))).toBe('');
+  });
+});
+
+describe('duration', () => {
+  it.each([
+    [Infinity, 'Infinity'],
+    [Number.NaN, 'NaN'],
+    [3600, '1:00:00'],
+    [359999, '99:59:59'],
+  ])('formats %o', (seconds, expected) => {
+    expect(duration(seconds)).toBe(expected);
+  });
+});
+
+describe('options', () => {
+  // A placeholder with no style carries no bag, and the functions read one
+  // either way.
+  it('reads an absent bag as empty', () => {
+    expect(options(undefined)).toEqual({});
+    expect(options(null)).toEqual({});
+    expect(options({ style: 'percent' })).toEqual({ style: 'percent' });
+  });
+});

--- a/packages/integration/src/messageformat/index.ts
+++ b/packages/integration/src/messageformat/index.ts
@@ -1,0 +1,40 @@
+import { parse } from '@messageformat/parser';
+import { MessageFormat } from 'messageformat';
+import { toMessage } from './convert.js';
+import { functions } from './functions.js';
+
+/**
+ * ICU MessageFormat 1, compiled in-tree.
+ *
+ * `@messageformat/icu-messageformat-1` does this already, and this folder owes
+ * it the select-flattening in `convert.ts`. What it cannot do is a skeleton on
+ * a date: it renders an argument's style into MF2's own option vocabulary, and
+ * that vocabulary has no room for one. `{d, date, ::yyyyMMdd}` survives the
+ * trip only as an unrecognised `mf1:argStyle`, which the formatter then reports
+ * as a bad option and renders as a fallback.
+ *
+ * Owning the conversion lets a style skip that vocabulary. A skeleton is
+ * resolved to an `Intl` options bag while the message is compiled, carried
+ * whole through the message data, and handed to `Intl` at format time — so
+ * `::yyyyMMdd` and `::currency/EUR` arrive by the same route as `short` and
+ * `integer`, and cost the same.
+ *
+ * The pipeline reads in one direction:
+ *
+ * - `styles.ts` — an argument style becomes `Intl` options
+ * - `options.ts` — the seam those options travel through
+ * - `convert.ts` — the MF1 tree becomes an MF2 message
+ * - `values.ts` / `functions.ts` — what the formatter runs
+ */
+
+/**
+ * Compile an ICU MessageFormat 1 message for a locale.
+ *
+ * @param locale Locale to format in
+ * @param source The message, in ICU MessageFormat 1 syntax
+ * @returns A formatter for the message
+ * @throws If the message is not valid ICU MessageFormat 1
+ */
+export function compile(locale: string, source: string) {
+  return new MessageFormat(locale, toMessage(parse(source)), { functions });
+}

--- a/packages/integration/src/messageformat/options.ts
+++ b/packages/integration/src/messageformat/options.ts
@@ -1,0 +1,32 @@
+import type { Model } from 'messageformat';
+
+/**
+ * Carry an `Intl` options bag whole, from conversion to formatting.
+ *
+ * MF2 declares an option value as a literal string, and every formatter it
+ * ships parses one back out of the string it was given. Nothing in between
+ * inspects the value — the resolver hands a literal to the function verbatim —
+ * so an already-parsed bag travels the same path unchanged, and a style is
+ * parsed once when the message is compiled rather than on every format.
+ *
+ * This is the one seam between the two halves of this folder: `styles.ts` fills
+ * a bag, `functions.ts` empties it, and nothing else looks inside.
+ */
+export const literal = <T>(value: T) => ({ type: 'literal', value }) as unknown as Model.Literal;
+
+/**
+ * Read back an options bag placed by {@link literal}.
+ *
+ * A message reaching the formatter always came through `compile`, so the bag is
+ * the one put there. The guard covers the value being absent, which is how a
+ * placeholder with no style is written.
+ */
+export function options<T extends object>(value: unknown): T {
+  return typeof value === 'object' && value !== null ? (value as T) : ({} as T);
+}
+
+/** The extra key a number's bag may carry, which `Intl` has no option for. */
+export type NumberOptions = Intl.NumberFormatOptions & { scale?: number };
+
+/** How a `plural` or `selectordinal` selector was written. */
+export type PluralOptions = { offset?: number; ordinal?: boolean };

--- a/packages/integration/src/messageformat/styles.ts
+++ b/packages/integration/src/messageformat/styles.ts
@@ -57,15 +57,21 @@ export function dateTimeStyle(kind: 'date' | 'time', style: string): Intl.DateTi
     const errors: string[] = [];
     const tokens = parseDateTokens(style.slice(2));
     const opt = getDateTimeFormatOptions(tokens, (_type, message) => errors.push(message));
-    // A skeleton that yielded nothing usable is a typo, not a format. Falling
-    // back to the locale default here would silently show the wrong fields.
-    if (Object.keys(opt).length === 0) throw new StyleError(errors[0] ?? `Empty skeleton ${style}`);
+    // Any field `Intl` could not show fails the whole skeleton. Keeping the
+    // fields that did resolve would answer a question nobody asked — a
+    // `::yMMMdqqqq` that quietly drops its quarter is the silent misformat this
+    // module exists to prevent, and it is what the build-time check rejects.
+    if (errors.length > 0) throw new StyleError(errors[0]!);
+    // Every token resolved and none of them named a field.
+    if (Object.keys(opt).length === 0) throw new StyleError(`Empty skeleton ${style}`);
     return opt;
   }
 
   // MF1's own default, for both `date` and `time`, is `medium`.
   if (style === '') return named.medium;
-  if (style in named) return named[style as keyof typeof named];
+  // `hasOwn` rather than `in`: the styles come from a plain object, so a key
+  // every object inherits must not pass for one an author asked for.
+  if (Object.hasOwn(named, style)) return named[style as keyof typeof named];
   throw new StyleError(`Unsupported ${kind} style ${style}`);
 }
 

--- a/packages/integration/src/messageformat/styles.ts
+++ b/packages/integration/src/messageformat/styles.ts
@@ -1,0 +1,119 @@
+import { getDateTimeFormatOptions, parseDateTokens } from '@messageformat/date-skeleton';
+import {
+  getNumberFormatOptions,
+  parseNumberPattern,
+  parseNumberSkeleton,
+} from '@messageformat/number-skeleton';
+import type { NumberOptions } from './options.js';
+
+/**
+ * An argument style, resolved to the `Intl` options it asks for.
+ *
+ * This is the half of the conversion that MF2's own option vocabulary cannot
+ * do. That vocabulary tops out at `{ length, fields }` for a date — a coarse
+ * `short`/`medium`/`long`/`full` and nothing else — so a skeleton has nowhere
+ * to land. Both skeleton parsers already emit `Intl` option bags, which is the
+ * form the formatter wants anyway, so a style resolves straight to one and
+ * skips the vocabulary entirely.
+ */
+
+/** A style the conversion could not read. */
+export class StyleError extends Error {}
+
+/**
+ * ICU's named date lengths, as the fields each one shows.
+ *
+ * MF1 names a length and leaves the fields to the locale; `Intl` wants both, so
+ * the names expand here. `full` and `long` differ only in the weekday, which is
+ * what distinguishes them in CLDR's own patterns.
+ */
+const DATE_STYLES = {
+  short: { year: 'numeric', month: 'numeric', day: 'numeric' },
+  medium: { year: 'numeric', month: 'short', day: 'numeric' },
+  long: { year: 'numeric', month: 'long', day: 'numeric' },
+  full: { year: 'numeric', month: 'long', day: 'numeric', weekday: 'long' },
+} as const satisfies Record<string, Intl.DateTimeFormatOptions>;
+
+const TIME_STYLES = {
+  short: { hour: 'numeric', minute: 'numeric' },
+  medium: { hour: 'numeric', minute: 'numeric', second: 'numeric' },
+  long: { hour: 'numeric', minute: 'numeric', second: 'numeric', timeZoneName: 'short' },
+  full: { hour: 'numeric', minute: 'numeric', second: 'numeric', timeZoneName: 'long' },
+} as const satisfies Record<string, Intl.DateTimeFormatOptions>;
+
+/**
+ * Turn a `date` or `time` argument style into `Intl.DateTimeFormat` options.
+ *
+ * A `::`-prefixed style is an ICU skeleton — `::yyyyMMdd`, `::HHmm` — naming
+ * the fields to show and leaving their arrangement to the locale. The named
+ * styles are looked up instead, and an empty style takes MF1's own default.
+ *
+ * @throws {StyleError} If the style names no fields
+ */
+export function dateTimeStyle(kind: 'date' | 'time', style: string): Intl.DateTimeFormatOptions {
+  const named = kind === 'date' ? DATE_STYLES : TIME_STYLES;
+
+  if (style.startsWith('::')) {
+    const errors: string[] = [];
+    const tokens = parseDateTokens(style.slice(2));
+    const opt = getDateTimeFormatOptions(tokens, (_type, message) => errors.push(message));
+    // A skeleton that yielded nothing usable is a typo, not a format. Falling
+    // back to the locale default here would silently show the wrong fields.
+    if (Object.keys(opt).length === 0) throw new StyleError(errors[0] ?? `Empty skeleton ${style}`);
+    return opt;
+  }
+
+  // MF1's own default, for both `date` and `time`, is `medium`.
+  if (style === '') return named.medium;
+  if (style in named) return named[style as keyof typeof named];
+  throw new StyleError(`Unsupported ${kind} style ${style}`);
+}
+
+/**
+ * Turn a `number` argument style into `Intl.NumberFormat` options.
+ *
+ * Three forms reach here: MF1's named styles, a `::`-prefixed skeleton, and a
+ * literal pattern such as `#,##0.00`.
+ *
+ * The named styles are expanded here rather than handed to a parser, because
+ * neither parser recognises them — they are MF1 vocabulary, and the pattern
+ * parser reads `percent` as seven literal characters. `currency` is not among
+ * them: MF1 has nowhere to write the code, so it is left to fall back to a
+ * plain number, and `::currency/EUR` is how a currency is asked for.
+ *
+ * `scale` comes back out alongside the bag rather than inside it, because it
+ * multiplies the value and `Intl` has no option for that.
+ *
+ * @throws {StyleError} If the style is not valid, or asks for something `Intl`
+ *   cannot express
+ */
+export function numberStyle(style: string): NumberOptions {
+  if (style === '') return {};
+  if (style === 'integer') return { maximumFractionDigits: 0 };
+  // `Intl` scales a percent itself, so this is the whole of ICU's
+  // `scale/100 percent`.
+  if (style === 'percent') return { style: 'percent' };
+
+  const errors: string[] = [];
+  const onError = (error: unknown) => errors.push(String(error));
+
+  // `parseNumberPattern` wants a currency code for the `¤` token, and a pattern
+  // without one never uses it. `XXX` is ISO 4217's "no currency" code, which is
+  // what an unadorned pattern should format as if one slips through.
+  const skeleton = style.startsWith('::')
+    ? parseNumberSkeleton(style.slice(2), onError)
+    : parseNumberPattern(style, 'XXX', onError);
+
+  let scale: number | undefined;
+  const opt: Intl.NumberFormatOptions = getNumberFormatOptions(skeleton, (stem, option) => {
+    if (stem === 'scale') scale = Number(option);
+    else errors.push(`Unsupported number stem ${stem}`);
+  });
+
+  if (errors.length > 0) throw new StyleError(errors[0]!);
+
+  // Double-scaling is not a risk here: `percent scale/100` is the one scale
+  // `Intl` can express, and the parser folds it into `style: 'percent'` rather
+  // than reporting it. Anything still reported — `::scale/1000` — is ours.
+  return scale === undefined ? opt : { ...opt, scale };
+}

--- a/packages/integration/src/messageformat/values.ts
+++ b/packages/integration/src/messageformat/values.ts
@@ -1,0 +1,156 @@
+import { getLocaleDir, type MessageValue } from 'messageformat/functions';
+
+/**
+ * A formatted part carries its direction only when that direction is known to
+ * be one of the two a reader can be isolated from. `auto` means undetermined,
+ * and saying so is what the absence of the key means.
+ */
+function part<T extends string, P>(type: T, locale: string, parts: P[]) {
+  const dir = getLocaleDir(locale);
+  // The locale here always came back from `Intl`, so its direction is always
+  // one of the two. The `auto` case is what an unresolvable locale would give.
+  /* v8 ignore next 3 */
+  return dir === 'ltr' || dir === 'rtl' ? { type, dir, locale, parts } : { type, locale, parts };
+}
+
+/**
+ * The resolved values a placeholder formats to.
+ *
+ * Each is a thin wrapper over one `Intl` formatter: MF2 asks a value for a
+ * string or for parts, and both questions are the formatter's to answer. The
+ * formatter is built lazily and kept, because `formatToParts` and `format` are
+ * often both asked of the same value and constructing an `Intl` formatter is
+ * the expensive half of formatting.
+ */
+
+// ===== Operands ===== //
+
+/**
+ * Read a numeric operand.
+ *
+ * A `bigint` is passed through rather than narrowed to `number`, since the
+ * point of one is the precision that conversion would lose.
+ *
+ * @throws If the value is not a number
+ */
+export function numeric(operand: unknown): number | bigint {
+  const value = typeof operand === 'object' && operand !== null ? operand.valueOf() : operand;
+  if (typeof value === 'bigint') return value;
+  const number = Number(value);
+  if (Number.isNaN(number) && value !== undefined) throw new Error('Input is not numeric');
+  return number;
+}
+
+/**
+ * Read a date operand, which may be written as a `Date`, an epoch offset, or
+ * anything `Date` can parse.
+ *
+ * @throws If the value is not a date
+ */
+export function temporal(operand: unknown): Date {
+  let value = operand;
+  if (typeof value === 'object' && value !== null && !(value instanceof Date)) {
+    value = value.valueOf();
+  }
+  if (typeof value === 'number' || typeof value === 'string') value = new Date(value);
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new Error('Input is not a valid date');
+  }
+  return value;
+}
+
+// ===== Values ===== //
+
+/**
+ * A number formatted by an `Intl.NumberFormat` options bag.
+ *
+ * Any scaling has already been applied to `value` — a scale is a multiplier on
+ * the number, not a way of writing it, so it belongs to the caller.
+ */
+export function number(
+  locales: string[],
+  value: number | bigint,
+  opt: Intl.NumberFormatOptions,
+): MessageValue<'number'> {
+  let nf: Intl.NumberFormat | undefined;
+  let locale: string | undefined;
+  const format = () => (nf ??= new Intl.NumberFormat(locales, opt));
+  const resolved = () => (locale ??= format().resolvedOptions().locale);
+
+  return {
+    type: 'number',
+    get dir() {
+      return getLocaleDir(resolved());
+    },
+    get options() {
+      return { ...opt };
+    },
+    toParts: () => [part('number', resolved(), format().formatToParts(value))],
+    toString: () => format().format(value),
+    valueOf: () => value,
+  };
+}
+
+/**
+ * A date or time formatted by an `Intl.DateTimeFormat` options bag.
+ *
+ * `date` and `time` share this: by the time a style has resolved, the two
+ * differ only in which fields their bag names.
+ */
+export function datetime(
+  locales: string[],
+  value: Date,
+  opt: Intl.DateTimeFormatOptions,
+): MessageValue<'datetime'> {
+  let dtf: Intl.DateTimeFormat | undefined;
+  let locale: string | undefined;
+  const format = () => (dtf ??= new Intl.DateTimeFormat(locales, opt));
+  const resolved = () => (locale ??= format().resolvedOptions().locale);
+
+  return {
+    type: 'datetime',
+    get dir() {
+      return getLocaleDir(resolved());
+    },
+    get options() {
+      return { ...opt };
+    },
+    toParts: () => [part('datetime', resolved(), format().formatToParts(value))],
+    toString: () => format().format(value),
+    valueOf: () => value,
+  };
+}
+
+/**
+ * `hhhh:mm:ss`, MF1's `duration` argument type.
+ *
+ * `Intl` has no equivalent — `DurationFormat` writes "1 hr, 2 min", not a clock
+ * reading — so this is the one format written out by hand.
+ */
+export function duration(seconds: number): string {
+  if (!Number.isFinite(seconds)) return String(seconds);
+
+  const sign = seconds < 0 ? '-' : '';
+  let value = Math.abs(seconds);
+
+  // A fractional second stays a string from here on. Rounding it to three
+  // places is the whole point, and `Number('1.500')` would undo that.
+  const secs = value % 60;
+  const parts: (string | number)[] = [Math.round(secs) === secs ? secs : secs.toFixed(3)];
+  if (value < 60) {
+    // One `:` is always written, so a sub-minute duration still reads as a
+    // duration rather than as a bare number of seconds.
+    parts.unshift(0);
+  } else {
+    value = Math.round((value - Number(parts[0])) / 60);
+    parts.unshift(value % 60);
+    if (value >= 60) parts.unshift(Math.round((value - Number(parts[0])) / 60));
+  }
+
+  // Every part but the first is padded to two digits, and the leading one is
+  // not — a duration reads as `1:01:01`, never `01:01:01`. The width is judged
+  // from the value rather than the text, so `1.500` pads like the 1 it is.
+  const first = parts.shift()!;
+  const pad = (n: string | number) => (Number(n) < 10 ? `0${n}` : String(n));
+  return sign + [first, ...parts.map(pad)].join(':');
+}

--- a/packages/integration/src/messageformat/values.ts
+++ b/packages/integration/src/messageformat/values.ts
@@ -131,21 +131,24 @@ export function duration(seconds: number): string {
   if (!Number.isFinite(seconds)) return String(seconds);
 
   const sign = seconds < 0 ? '-' : '';
-  let value = Math.abs(seconds);
+
+  // Round to the millisecond *before* splitting the value up. Rounding a
+  // seconds field that is already 59.9999 gives `60`, which has to carry into
+  // the minutes — rounding it in place would write `0:60.000`.
+  const total = Math.round(Math.abs(seconds) * 1000) / 1000;
+
+  const secs = total % 60;
+  const minutes = Math.floor(total / 60);
+  const hours = Math.floor(minutes / 60);
 
   // A fractional second stays a string from here on. Rounding it to three
   // places is the whole point, and `Number('1.500')` would undo that.
-  const secs = value % 60;
-  const parts: (string | number)[] = [Math.round(secs) === secs ? secs : secs.toFixed(3)];
-  if (value < 60) {
-    // One `:` is always written, so a sub-minute duration still reads as a
-    // duration rather than as a bare number of seconds.
-    parts.unshift(0);
-  } else {
-    value = Math.round((value - Number(parts[0])) / 60);
-    parts.unshift(value % 60);
-    if (value >= 60) parts.unshift(Math.round((value - Number(parts[0])) / 60));
-  }
+  const written = Math.round(secs) === secs ? String(secs) : secs.toFixed(3);
+
+  // One `:` is always written, so a sub-minute duration still reads as a
+  // duration rather than as a bare number of seconds.
+  const parts: (string | number)[] =
+    hours > 0 ? [hours, minutes % 60, written] : [minutes, written];
 
   // Every part but the first is padded to two digits, and the leading one is
   // not — a duration reads as `1:01:01`, never `01:01:01`. The width is judged

--- a/packages/integration/src/runtime.test.ts
+++ b/packages/integration/src/runtime.test.ts
@@ -339,6 +339,71 @@ describe('formatted arguments', () => {
     expect(format(message, values)).toBe(expected);
   });
 
+  // Skeletons are why the MF1 conversion is ours rather than the upstream
+  // package's: it renders a style into MF2's option vocabulary, which has no
+  // word for a currency on a number or for any of these fields on a date.
+  it.each([
+    ['{n, number, ::.00}', { n: 1234.5 }, '1,234.50'],
+    ['{n, number, ::group-off}', { n: 1234.5 }, '1234.5'],
+    ['{n, number, ::compact-short}', { n: 12345 }, '12K'],
+    ['{n, number, ::scale/1000}', { n: 1.5 }, '1,500'],
+    // A skeleton's `percent` only writes the sign. The named MF1 style scales
+    // as well, which is `percent scale/100` spelled out.
+    ['{n, number, ::percent}', { n: 25 }, '25%'],
+    ['{n, number, ::percent scale/100}', { n: 0.25 }, '25%'],
+  ])('formats the number skeleton %s', (message, values, expected) => {
+    expect(format(message, values)).toBe(expected);
+  });
+
+  // MF1 has nowhere to write a currency code, so `{n, number, currency}` cannot
+  // name one and falls back to a plain number. A skeleton carries the code.
+  it('formats a currency, which only a skeleton can ask for', () => {
+    expect(format('{n, number, ::currency/EUR}', { n: 1234.5 })).toBe('€1,234.50');
+    expect(format('{n, number, currency}', { n: 1234.5 })).toBe('1,234.5');
+  });
+
+  it.each([
+    ['{d, date, ::yyyyMMdd}', '01/02/2020'],
+    ['{d, date, ::yMMMM}', 'January 2020'],
+    ['{d, date, ::MMMd}', 'Jan 2'],
+    ['{d, date, ::EEEE}', 'Thursday'],
+    ['{d, time, ::Hm}', '12:04'],
+  ])('formats the date skeleton %s', (message, expected) => {
+    expect(format(message, { d: when })).toBe(expected);
+  });
+
+  // A style is authored once and read by everyone. A message that renders in a
+  // slightly wrong shape is recoverable; one that renders `{$d}` is not.
+  it.each([
+    ['{d, date, bogus}', 'Jan 2, 2020'],
+    ['{d, date, ::qqqq}', 'Jan 2, 2020'],
+  ])('falls back to the default format for %s', (message, expected) => {
+    expect(format(message, { d: when })).toBe(expected);
+  });
+
+  it('falls back to a plain number for an unreadable number style', () => {
+    expect(format('{n, number, ::bogus}', { n: 1234.5 })).toBe('1,234.5');
+  });
+
+  // No macro authors a `duration`, so this only ever arrives from a catalogue
+  // written by hand. `Intl` has no clock-reading format, so we write it out.
+  it.each([
+    [0, '0:00'],
+    [5, '0:05'],
+    [61, '1:01'],
+    [3661, '1:01:01'],
+    [-61, '-1:01'],
+    [1.5, '0:01.500'],
+  ])('formats {n, duration} of %d', (n, expected) => {
+    expect(plain(format('{n, duration}', { n }))).toBe(expected);
+  });
+
+  // An argument type with no formatter still writes its value, rather than
+  // taking the rest of the message down with it.
+  it('falls back to the plain value for an unknown argument type', () => {
+    expect(plain(format('{n, spellout}', { n: 42 }))).toBe('42');
+  });
+
   it.each([
     ['{d, date}', 'Jan 2, 2020'],
     ['{d, date, short}', '1/2/2020'],

--- a/packages/integration/src/runtime.ts
+++ b/packages/integration/src/runtime.ts
@@ -1,4 +1,4 @@
-import { mf1ToMessage } from '@messageformat/icu-messageformat-1';
+import { compile } from './messageformat/index.js';
 import type {
   DateTimeOptions,
   Disallow,
@@ -89,7 +89,7 @@ export class Say<
   #locales: Locale[];
   #loader?: Loader;
   #messages: Map<Locale, Say.Messages>;
-  #formats: Map<string, ReturnType<typeof mf1ToMessage>>;
+  #formats: Map<string, ReturnType<typeof compile>>;
   #active: Locale | undefined;
 
   constructor(options: Say.Options<Locale, Loader>) {
@@ -278,7 +278,7 @@ export class Say<
 
     const key = `${locale}:${descriptor.id}`;
     const format =
-      this.#formats.get(key) ?? this.#formats.set(key, mf1ToMessage(locale, message)).get(key)!;
+      this.#formats.get(key) ?? this.#formats.set(key, compile(locale, message)).get(key)!;
     return String(format.format(resolveDescriptorValues(descriptor)));
   }
 
@@ -382,10 +382,12 @@ export class Say<
    * say`You have ${say.number(items.length)} items`
    * say`Battery at ${say.number(level, { style: 'percent' })}`
    * say`Total: ${say.number({ cartTotal: getTotal() }, { style: '#,##0.00' })}`
+   * say`Total: ${say.number(total, { style: '::currency/EUR' })}`
    * ```
    *
    * @param _ Number to format
-   * @param options Formatting style, either a named style or a literal number pattern
+   * @param options Formatting style: a named style, an ICU skeleton such as
+   *   `::currency/EUR`, or a literal number pattern such as `#,##0.00`
    * @returns The formatted number
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
@@ -402,10 +404,12 @@ export class Say<
    * ```ts
    * say`Published ${say.date(post.publishedAt)}`
    * say`Published ${say.date(post.publishedAt, { style: 'full' })}`
+   * say`Published ${say.date(post.publishedAt, { style: '::yMMMM' })}`
    * ```
    *
    * @param _ Date to format
-   * @param options Formatting style
+   * @param options Formatting style, either a named style or an ICU skeleton
+   *   such as `::yyyyMMdd`
    * @returns The formatted date
    * @remark This is a macro and must be used with the relevant saykit plugin
    */
@@ -425,10 +429,12 @@ export class Say<
    * ```ts
    * say`Doors open at ${say.time(opensAt)}`
    * say`Doors open at ${say.time(opensAt, { style: 'short' })}`
+   * say`Doors open at ${say.time(opensAt, { style: '::Hm' })}`
    * ```
    *
    * @param _ Date to format
-   * @param options Formatting style
+   * @param options Formatting style, either a named style or an ICU skeleton
+   *   such as `::Hm`
    * @returns The formatted time
    * @remark This is a macro and must be used with the relevant saykit plugin
    */

--- a/packages/integration/src/types.ts
+++ b/packages/integration/src/types.ts
@@ -38,20 +38,29 @@ export interface SelectOptions<Branch = string> {
 }
 
 /**
+ * An ICU skeleton: a `::`-prefixed description of the parts a value is written
+ * with, rather than a name for a whole format. `::currency/EUR` and
+ * `::yyyyMMdd` say what to show and leave the arrangement to the locale.
+ *
+ * A skeleton is where the formats the named styles have no word for live —
+ * currency, compact notation, a year and month with no day — so every argument
+ * type accepts one alongside its named styles.
+ */
+export type Skeleton = `::${string}`;
+
+/**
  * Formatting for a `{arg, number}` placeholder.
  *
- * `currency` is not offered: MF1 has nowhere to write the currency code, so
- * `{price, number, currency}` formats as a literal `{$price}` rather than an
- * amount. A literal pattern such as `#,##0.00` is accepted for the cases the
- * named styles do not cover.
+ * A literal `NumberFormat` pattern such as `#,##0.00` is also accepted, for the
+ * cases neither the named styles nor a skeleton spell more clearly.
  */
 export interface NumberOptions {
-  style?: 'integer' | 'percent' | (string & {});
+  style?: 'integer' | 'percent' | Skeleton | (string & {});
 }
 
 /**
  * Formatting for a `{arg, date}` or `{arg, time}` placeholder.
  */
 export interface DateTimeOptions {
-  style?: 'short' | 'medium' | 'long' | 'full';
+  style?: 'short' | 'medium' | 'long' | 'full' | Skeleton;
 }

--- a/packages/transform-js/src/parser.test.ts
+++ b/packages/transform-js/src/parser.test.ts
@@ -360,6 +360,21 @@ describe('parseCallExpression', () => {
     );
   });
 
+  it.each([
+    ['date', '::yyyyMMdd'],
+    ['number', '::currency/EUR'],
+  ] as const)('parses a %s call expression with the skeleton %s', (kind, style) => {
+    const result = parser.parseCallExpression(expr(`say.${kind}(v, { style: '${style}' })`));
+    const argument = result!.children[0] as ArgumentMessage;
+    expect(argument.format).toEqual({ type: kind, style });
+  });
+
+  it('rejects a skeleton the formatter cannot resolve', () => {
+    expect(() => parser.parseCallExpression(expr("say.date(when, { style: '::qqqq' })"))).toThrow(
+      "Invalid date skeleton '::qqqq'",
+    );
+  });
+
   // The style is baked into the extracted message, so a value only known at
   // runtime cannot name one. It is dropped rather than guessed at.
   it('ignores a style that is not a string literal', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,12 @@ importers:
       '@commander-js/extra-typings':
         specifier: ^15.0.0
         version: 15.0.0(commander@15.0.0)
+      '@messageformat/date-skeleton':
+        specifier: 2.0.0-0
+        version: 2.0.0-0
+      '@messageformat/number-skeleton':
+        specifier: 2.0.0-0
+        version: 2.0.0-0
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -445,9 +451,18 @@ importers:
 
   packages/integration:
     dependencies:
-      '@messageformat/icu-messageformat-1':
-        specifier: ^0.12.0
-        version: 0.12.0
+      '@messageformat/date-skeleton':
+        specifier: 2.0.0-0
+        version: 2.0.0-0
+      '@messageformat/number-skeleton':
+        specifier: 2.0.0-0
+        version: 2.0.0-0
+      '@messageformat/parser':
+        specifier: ^5.1.1
+        version: 5.1.1
+      messageformat:
+        specifier: ^4.0.0
+        version: 4.0.0
 
   packages/integration-carbon:
     devDependencies:
@@ -2516,10 +2531,6 @@ packages:
 
   '@messageformat/date-skeleton@2.0.0-0':
     resolution: {integrity: sha512-gkCatAK4MYlhjKYWxkfRM6Ql0M1VmA1DK6A9rszUBprZpQox/XqX987AI2w7YoEz0p5DgkPOpI6PK1mW08yNqQ==}
-
-  '@messageformat/icu-messageformat-1@0.12.0':
-    resolution: {integrity: sha512-vCpR24LBD6cSwaQ2lUJLXeJ0Ls+qT9PTh+z8RHrtazLLOJj0Y5IaVflLCWPm5NBM3IYKwklQsge25MCmMWppAg==}
-    engines: {node: ^20.19 || ^22.12 || >=24}
 
   '@messageformat/number-skeleton@2.0.0-0':
     resolution: {integrity: sha512-bDrIrVSKwn0sNrbU+N6tjwljV+Zl9pRCR/D9Xim6Q7lLzZ20nFYtuuKOZ3QKisN+vPxa9sTqu3ufJ+uwKNpHbQ==}
@@ -10343,13 +10354,6 @@ snapshots:
 
   '@messageformat/date-skeleton@2.0.0-0': {}
 
-  '@messageformat/icu-messageformat-1@0.12.0':
-    dependencies:
-      '@messageformat/date-skeleton': 2.0.0-0
-      '@messageformat/number-skeleton': 2.0.0-0
-      '@messageformat/parser': 5.1.1
-      messageformat: 4.0.0
-
   '@messageformat/number-skeleton@2.0.0-0': {}
 
   '@messageformat/parser@5.1.1':
@@ -12230,7 +12234,7 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   babel-plugin-react-native-web@0.21.2: {}
 

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -311,8 +311,11 @@ say`Since ${say.date(joined, { style: '::yMMMM' })}`; // → "Since January 2020
 say`Doors at ${say.time(opensAt, { style: '::Hm' })}`; // → "Doors at 19:30"
 ```
 
-A skeleton is checked at build time by being resolved, so a typo like `::qqqq` fails with a file and
-a line rather than reaching a reader.
+A skeleton is checked at build time by being resolved, not by being matched against a list, so it
+fails with a file and a line rather than reaching a reader. That covers more than typos: `::qqqq` is
+perfectly good ICU — a stand-alone quarter — but `Intl` has no way to show one, so it is rejected
+too. A skeleton is rejected whole, so `::yMMMdqqqq` fails rather than quietly dropping the quarter
+and formatting the rest.
 
 <Callout>
   There is no `currency` **style**, because ICU MessageFormat 1 has nowhere to write the code. A
@@ -433,10 +436,10 @@ string attribute has nowhere to put a value:
 
 <Callout type="info">
   A message extracts as the text JSX renders, so a line break and the indentation around it are
-  layout and never reach a catalogue. Whitespace that has to survive a break is written as ` ` — the
-  same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the space
-  it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is read
-  the same way, as the text it renders as.
+  layout and never reach a catalogue. Whitespace that has to survive a break is written as `{' '}` —
+  the same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the
+  space it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is
+  read the same way, as the text it renders as.
 </Callout>
 
 <Callout type="info">

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -275,14 +275,14 @@ the macros above, these are **fragments** rather than whole messages, so they go
 say`You have ${say.number(items.length)} items`;
 say`Battery at ${say.number(level, { style: 'percent' })}`;
 say`Published ${say.date(post.publishedAt, { style: 'long' })}`;
-say`Total: ${say.number({ cartTotal: getTotal() })}`;
+say`Total: ${say.number({ cartTotal: getTotal() }, { style: '::currency/EUR' })}`;
 ```
 
 ```text
 You have {0, number} items
 Battery at {0, number, percent}
 Published {0, date, long}
-Total: {cartTotal, number}
+Total: {cartTotal, number, ::currency/EUR}
 ```
 
 Naming works as it does anywhere else. The reason to write these rather than call `Intl` yourself is
@@ -292,21 +292,38 @@ put the number somewhere else entirely.
 `style` is optional, and omitting it still gives locale-aware output, `{n, number}` applies the right
 grouping separators and decimal mark. An unrecognised style fails the build.
 
-| Macro        | Styles                                                     |
-| ------------ | ---------------------------------------------------------- |
-| `say.number` | `integer`, `percent`, or a literal pattern like `#,##0.00` |
-| `say.date`   | `short`, `medium`, `long`, `full`                          |
-| `say.time`   | `short`, `medium`, `long`, `full`                          |
+| Macro        | Styles                                                                 |
+| ------------ | ---------------------------------------------------------------------- |
+| `say.number` | `integer`, `percent`, a skeleton, or a literal pattern like `#,##0.00` |
+| `say.date`   | `short`, `medium`, `long`, `full`, or a skeleton                       |
+| `say.time`   | `short`, `medium`, `long`, `full`, or a skeleton                       |
 
-<Callout type="warn">
-  There is no `currency` style, because ICU MessageFormat 1 has nowhere to write the currency code.
-  Format currency with `Intl.NumberFormat` and interpolate the result, its position in the sentence
-  stays translatable even though its formatting does not.
+### Skeletons
+
+A named style asks for a whole format. A **skeleton** — written with a `::` prefix — asks for the
+parts instead, and leaves their arrangement to the locale. It is how you reach the formats the four
+names have no word for:
+
+```ts
+say`Total ${say.number(total, { style: '::currency/EUR' })}`; // → "Total €1,234.50"
+say`${say.number(views, { style: '::compact-short' })} views`; // → "12K views"
+say`Since ${say.date(joined, { style: '::yMMMM' })}`; // → "Since January 2020"
+say`Doors at ${say.time(opensAt, { style: '::Hm' })}`; // → "Doors at 19:30"
+```
+
+A skeleton is checked at build time by being resolved, so a typo like `::qqqq` fails with a file and
+a line rather than reaching a reader.
+
+<Callout>
+  There is no `currency` **style**, because ICU MessageFormat 1 has nowhere to write the code. A
+  currency skeleton names it — `::currency/EUR` — which is the way to ask for one.
 </Callout>
 
-Skeletons (`::compact-short`, `::yMMMd`) are not supported, the runtime formatter rejects them, which
-also rules out compact notation and units. Neither are `spellout` or ICU's rule-based `ordinal`,
-which have no `Intl` equivalent, or `choice`, deprecated in ICU itself in favour of `plural`.
+A skeleton's `::percent` writes the sign but does not scale, so `0.25` formats as `0.25%`. The named
+`percent` style scales as well, which is `::percent scale/100` spelled out.
+
+`spellout` and ICU's rule-based `ordinal` are still unsupported, having no `Intl` equivalent, as is
+`choice`, deprecated in ICU itself in favour of `plural`.
 
 ## Descriptors
 
@@ -416,10 +433,10 @@ string attribute has nowhere to put a value:
 
 <Callout type="info">
   A message extracts as the text JSX renders, so a line break and the indentation around it are
-  layout and never reach a catalogue. Whitespace that has to survive a break is written as `{' '}` —
-  the same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the
-  space it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is
-  read the same way, as the text it renders as.
+  layout and never reach a catalogue. Whitespace that has to survive a break is written as ` ` — the
+  same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the space
+  it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is read
+  the same way, as the text it renders as.
 </Callout>
 
 <Callout type="info">

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -115,9 +115,10 @@ an ICU skeleton, which is how you ask for a currency or for fields the named sty
 
 See [Messages](/core-concepts/messages#numbers-dates-and-times) for what each one extracts to.
 
-<Callout type="warn">
-  Don't use the `{' '}` spacing escape inside a `<Say>`. It is an expression child like any other, so
-  it extracts as a placeholder and leaves a translator moving a stray space around the sentence.
+<Callout type="info">
+  The `{' '}` spacing escape is safe inside a `<Say>`. A literal expression child is read as the text
+  it renders as, so it folds into the words around it and reaches a translator as one run of text
+  rather than as a placeholder they can neither see nor move.
 </Callout>
 
 ### Descriptors

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -103,9 +103,17 @@ They are fragments rather than whole messages, so they nest inside a `<Say>`:
 ```
 
 `style` is optional: `integer` or `percent` on `<Say.Number>` (or a pattern like `#,##0.00`), and
-`short`, `medium`, `long`, or `full` on `<Say.Date>` and `<Say.Time>`. See
-[Messages](/core-concepts/messages#numbers-dates-and-times) for what each one extracts to, and why
-there is no `currency`.
+`short`, `medium`, `long`, or `full` on `<Say.Date>` and `<Say.Time>`. Every one of them also takes
+an ICU skeleton, which is how you ask for a currency or for fields the named styles cannot spell:
+
+```tsx
+<Say>
+  Total <Say.Number _={total} style="::currency/EUR" /> since
+  <Say.Date _={{ joined }} style="::yMMMM" />
+</Say>
+```
+
+See [Messages](/core-concepts/messages#numbers-dates-and-times) for what each one extracts to.
 
 <Callout type="warn">
   Don't use the `{' '}` spacing escape inside a `<Say>`. It is an expression child like any other, so

--- a/website/content/reference/api/saykit.mdx
+++ b/website/content/reference/api/saykit.mdx
@@ -212,10 +212,13 @@ would otherwise be numbered. The wrapper is read at build time and never reaches
 ```ts
 say`Your total is ${{ cartTotal: getCartTotal() }}`; // → "Your total is {cartTotal}"
 
-say.plural({ items: cart.length }, {
-  one: `${{ items: cart.length }} item`,
-  other: `${{ items: cart.length }} items`,
-});
+say.plural(
+  { items: cart.length },
+  {
+    one: `${{ items: cart.length }} item`,
+    other: `${{ items: cart.length }} items`,
+  },
+);
 ```
 
 The name must be a valid identifier, an invalid one fails the build. See
@@ -250,6 +253,19 @@ Either `messages` is required (and `loader` optional), or `loader` is required (
 ### `NumeralOptions` / `SelectOptions`
 
 Option-bag types for `plural`, `ordinal`, and `select`. Both require an `other` key.
+
+### `NumberOptions` / `DateTimeOptions`
+
+Option-bag types for `number`, `date`, and `time`. Each carries an optional `style`.
+
+### `Skeleton`
+
+```ts
+type Skeleton = `::${string}`;
+```
+
+An ICU skeleton, accepted as a `style` by every format macro. See
+[Skeletons](/core-concepts/messages#skeletons).
 
 ## Next
 


### PR DESCRIPTION
`@messageformat/icu-messageformat-1` renders an argument's style into MF2's own option vocabulary, and that vocabulary tops out at `{ length, fields }` for a date. `{d, date, ::yyyyMMdd}` has nowhere to land, so it survives only as an unrecognised `mf1:argStyle` that the formatter reports as a bad option.

This replaces that package with an in-tree conversion so a style can skip the vocabulary. Both skeleton parsers already emit `Intl` option bags, so a style now resolves to one when the message is compiled, rides through the message data whole, and goes straight to `Intl` at format time — `::yyyyMMdd` and `::currency/EUR` arrive by the same route as `short` and `integer`, and cost the same.

```ts
say`Total ${say.number(total, { style: '::currency/EUR' })}`;  // → "Total €1,234.50"
say`${say.number(views, { style: '::compact-short' })} views`; // → "12K views"
say`Since ${say.date(joined, { style: '::yMMMM' })}`;          // → "Since January 2020"
```

## Layout

`packages/integration/src/messageformat/`, split along the pipeline:

| file | role |
| --- | --- |
| `styles.ts` | argument style → `Intl` options — the part upstream cannot do |
| `options.ts` | the seam those options travel through |
| `convert.ts` | MF1 tree → MF2 message (select-flattening, adapted from upstream, Apache-2.0) |
| `values.ts` / `functions.ts` | what the formatter runs |

## Validated at build time

`validateArgumentStyle` now accepts skeletons and checks them by *resolving* them with the same parsers the runtime formats with, so `::qqqq` fails with a file and a line rather than reaching a reader. An unresolvable style still falls back to the bare formatter at runtime — a message authored once and read by everyone is better slightly wrong than broken.

## Two bugs fixed along the way

Both found while covering the new folder:

- **`toParts` dropped `dir`**, losing bidi information for `formatToParts` consumers.
- **Selecting one argument twice at different offsets crashed** with `duplicate-declaration`, since both selectors declared the same name. Confirmed upstream throws identically, so not a regression — later selectors now get a generated name and a `local` declaration, and a plural reports the number the message was given rather than the already-offset one.

## Notes

- No breaking changes; every existing style keeps its behaviour.
- A skeleton's bare `::percent` writes the sign but does **not** scale (`0.25` → `0.25%`). The named `percent` style scales too, which is `::percent scale/100`. That is ICU's semantics; both are tested.
- `packages/integration/src/messageformat` is at 100% statements, branches, and functions. Three genuinely unreachable guards carry `/* v8 ignore */` with the reason rather than a contorted test.
- Docs corrected — they previously stated skeletons were unsupported and currency was impossible.

630 tests pass; build, lint, and typecheck clean across all packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ICU skeletons when formatting numbers, dates and times.
  * Added currency, percentage scaling, duration, plural and ordinal formatting capabilities.
  * Improved compatibility with ICU MessageFormat messages, including selectors and plural offsets.
  * Added graceful fallbacks for unsupported or invalid formatting styles.

* **Documentation**
  * Updated API and integration guidance with skeleton syntax and currency examples.
  * Added validation guidance and examples for supported formatting styles.

* **Bug Fixes**
  * Improved handling of formatted values, parts, dates, durations and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->