### PR TITLE
Ship smaller builds and stop publishing unplugin's test bundle

### DIFF
--- a/.changeset/brave-moons-shave.md
+++ b/.changeset/brave-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'unplugin-saykit': patch
+---
+
+Stop publishing the test bundle, which took the package from 574kb to 4kb

--- a/.changeset/lucky-days-repeat.md
+++ b/.changeset/lucky-days-repeat.md
@@ -1,0 +1,13 @@
+---
+'saykit': patch
+'@saykit/react': patch
+'@saykit/carbon': patch
+'@saykit/config': patch
+'@saykit/format-json': patch
+'@saykit/format-po': patch
+'babel-plugin-saykit': patch
+'@saykit/transform-js': patch
+'@saykit/transform-jsx': patch
+---
+
+Ship smaller builds, keeping doc comments in the type declarations rather than the code

--- a/.changeset/olive-pugs-marry.md
+++ b/.changeset/olive-pugs-marry.md
@@ -1,6 +1,5 @@
 ---
 'babel-plugin-saykit': patch
-'@saykit/config': patch
 ---
 
-Take `@babel/core` from the plugin API rather than as a dependency, and hash with `node:crypto` rather than `js-sha256`
+Take `@babel/core` from the plugin API rather than as a dependency

--- a/.changeset/olive-pugs-marry.md
+++ b/.changeset/olive-pugs-marry.md
@@ -1,0 +1,6 @@
+---
+'babel-plugin-saykit': patch
+'@saykit/config': patch
+---
+
+Take `@babel/core` from the plugin API rather than as a dependency, and hash with `node:crypto` rather than `js-sha256`

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "tsdown": "^0.22.14",
     "turbo": "^2.10.7",
     "typescript": "^6.0.3",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.10"
   },
   "packageManager": "pnpm@11.17.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -82,7 +82,6 @@
     "@messageformat/date-skeleton": "2.0.0-0",
     "@messageformat/number-skeleton": "2.0.0-0",
     "commander": "^15.0.0",
-    "js-sha256": "^0.12.0",
     "picomatch": "^4.0.5",
     "zod": "^4.4.3"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -82,6 +82,7 @@
     "@messageformat/date-skeleton": "2.0.0-0",
     "@messageformat/number-skeleton": "2.0.0-0",
     "commander": "^15.0.0",
+    "js-sha256": "^0.12.0",
     "picomatch": "^4.0.5",
     "zod": "^4.4.3"
   },

--- a/packages/config/src/features/messages/hash.ts
+++ b/packages/config/src/features/messages/hash.ts
@@ -1,8 +1,23 @@
-import { createHash } from 'node:crypto';
+import { sha256 } from 'js-sha256';
 
+/**
+ * Hashed in userland rather than with `node:crypto`, because this runs wherever
+ * a bundler runs it. `createHash` is one of the entry points `unenv` leaves
+ * unimplemented — "[unenv] crypto.createHash is not implemented yet!" — so a
+ * plugin reaching for it throws in a Nitro or workerd build. The Web Crypto
+ * equivalent, `subtle.digest`, is async, and an id is resolved from a
+ * synchronous extraction pass.
+ */
 export function generateHash(input: string, context?: string) {
-  return createHash('sha256')
-    .update(`${input}\u{001F}${context || ''}`)
-    .digest('base64url')
+  const hasher = sha256.create();
+  hasher.update(`${input}\u{001F}${context || ''}`);
+  const result = hasher.toString();
+
+  const elements = result.match(/.{1,2}/g)?.map((b) => parseInt(b, 16)) || [];
+  const bytes = Uint8Array.from(elements);
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
     .slice(0, 6);
 }

--- a/packages/config/src/features/messages/hash.ts
+++ b/packages/config/src/features/messages/hash.ts
@@ -1,15 +1,8 @@
-import { sha256 } from 'js-sha256';
+import { createHash } from 'node:crypto';
 
 export function generateHash(input: string, context?: string) {
-  const hasher = sha256.create();
-  hasher.update(`${input}\u{001F}${context || ''}`);
-  const result = hasher.toString();
-
-  const elements = result.match(/.{1,2}/g)?.map((b) => parseInt(b, 16)) || [];
-  const bytes = Uint8Array.from(elements);
-  return btoa(String.fromCharCode(...bytes))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '')
+  return createHash('sha256')
+    .update(`${input}\u{001F}${context || ''}`)
+    .digest('base64url')
     .slice(0, 6);
 }

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -10,4 +10,5 @@ export default defineConfig({
   ],
   format: ['esm', 'cjs'],
   dts: true,
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/format-json/tsdown.config.ts
+++ b/packages/format-json/tsdown.config.ts
@@ -2,4 +2,5 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/formatter.ts'],
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/format-po/tsdown.config.ts
+++ b/packages/format-po/tsdown.config.ts
@@ -2,4 +2,5 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/formatter.ts'],
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/integration-carbon/package.json
+++ b/packages/integration-carbon/package.json
@@ -24,6 +24,7 @@
     "!dist/**/*.map"
   ],
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/packages/integration-carbon/tsdown.config.ts
+++ b/packages/integration-carbon/tsdown.config.ts
@@ -2,4 +2,5 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts'],
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/integration-react/tsdown.config.ts
+++ b/packages/integration-react/tsdown.config.ts
@@ -6,7 +6,8 @@ const SERVER_IMPORT = 'import { getSay as GET_SAY } from "./server.mjs";';
 
 export default defineConfig({
   entry: ['src/runtime/index.ts', 'src/runtime/client.ts', 'src/runtime/server.ts'],
-  target: 'es2020',
+  target: 'es2022',
+  outputOptions: { comments: { jsdoc: false } },
   async onSuccess() {
     const index = await readFile('dist/index.mjs', 'utf8');
     await writeFile('dist/index.server.mjs', SERVER_IMPORT + index);

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -25,6 +25,7 @@
     "!dist/**/*.map"
   ],
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/runtime.d.mts",

--- a/packages/integration/tsdown.config.ts
+++ b/packages/integration/tsdown.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/runtime.ts'],
-  target: 'es2020',
+  target: 'es2022',
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -53,10 +53,13 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
-    "@babel/core": "^7.29.7",
     "@saykit/config": "workspace:^"
   },
   "devDependencies": {
+    "@babel/core": "^7.29.7",
     "@types/babel__core": "^7.20.5"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0 || ^8.0.0"
   }
 }

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,5 +1,5 @@
 import { dirname, relative, resolve } from 'node:path';
-import { types as t, type PluginObj, type parse as Parse } from '@babel/core';
+import type { ConfigAPI, PluginObj, parse as Parse, types } from '@babel/core';
 import { resolveConfig } from '@saykit/config/features/loader';
 import { loadCatalogue } from './catalogue.js';
 
@@ -26,7 +26,10 @@ export interface Options {
   catalogues?: 'inline' | 'module';
 }
 
-export default (_: unknown, { catalogues = 'inline' }: Options = {}): PluginObj => {
+export default (
+  { types: t }: ConfigAPI & { types: typeof types },
+  { catalogues = 'inline' }: Options = {},
+): PluginObj => {
   const config = resolveConfig();
 
   return {

--- a/packages/plugin-babel/tsdown.config.ts
+++ b/packages/plugin-babel/tsdown.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
     'src/next/loader.ts',
   ],
   format: 'cjs',
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/plugin-unplugin/tsdown.config.ts
+++ b/packages/plugin-unplugin/tsdown.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/*.ts'],
+  entry: ['src/index.ts', 'src/*.ts', '!src/*.test.ts'],
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/transform-js/tsdown.config.ts
+++ b/packages/transform-js/tsdown.config.ts
@@ -2,4 +2,5 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/parser.ts', 'src/generator.ts'],
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/packages/transform-jsx/tsdown.config.ts
+++ b/packages/transform-jsx/tsdown.config.ts
@@ -2,4 +2,5 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/parser.ts', 'src/generator.ts'],
+  outputOptions: { comments: { jsdoc: false } },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
+      js-sha256:
+        specifier: ^0.12.0
+        version: 0.12.0
       picomatch:
         specifier: ^4.0.5
         version: 4.0.5
@@ -6014,6 +6017,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-sha256@0.12.0:
+    resolution: {integrity: sha512-P2IyTRMIHCkLD9clcQST8wGP/wqOXjvDD7E3onloE/5LSQGscyrmk2Loa069YsdtLfQWN1EnMDiaomAs9AfP4w==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -13698,6 +13704,8 @@ snapshots:
   jimp-compact@0.16.1: {}
 
   jiti@2.7.0: {}
+
+  js-sha256@0.12.0: {}
 
   js-tokens@10.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -338,7 +335,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.15)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start':
         specifier: ^1.168.32
-        version: 1.168.32(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 1.168.32(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -419,9 +416,6 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
-      js-sha256:
-        specifier: ^0.12.0
-        version: 0.12.0
       picomatch:
         specifier: ^4.0.5
         version: 4.0.5
@@ -503,13 +497,13 @@ importers:
 
   packages/plugin-babel:
     dependencies:
-      '@babel/core':
-        specifier: ^7.29.7
-        version: 7.29.7(supports-color@10.2.2)
       '@saykit/config':
         specifier: workspace:^
         version: link:../config
     devDependencies:
+      '@babel/core':
+        specifier: ^7.29.7
+        version: 7.29.7(supports-color@10.2.2)
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -5765,9 +5759,6 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   goober@2.1.19:
     resolution: {integrity: sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==}
     peerDependencies:
@@ -6023,9 +6014,6 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
-
-  js-sha256@0.12.0:
-    resolution: {integrity: sha512-P2IyTRMIHCkLD9clcQST8wGP/wqOXjvDD7E3onloE/5LSQGscyrmk2Loa069YsdtLfQWN1EnMDiaomAs9AfP4w==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -7630,17 +7618,6 @@ packages:
   ts-morph@28.0.0:
     resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsdown@0.22.14:
     resolution: {integrity: sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
@@ -7871,11 +7848,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.1.5:
     resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
@@ -8226,6 +8198,26 @@ snapshots:
   '@babel/compat-data@8.0.0':
     optional: true
 
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -8366,6 +8358,15 @@ snapshots:
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
@@ -11472,14 +11473,14 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@tanstack/react-start-rsc@0.1.31(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/react-start-rsc@0.1.31(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/router-core': 1.171.15
-      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
+      '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17
       '@tanstack/start-storage-context': 1.167.17
       pathe: 2.0.3
@@ -11509,15 +11510,15 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.32(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/react-start@1.168.32(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-start-client': 1.168.16(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/react-start-rsc': 0.1.31(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/react-start-rsc': 0.1.31(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
+      '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.14
-      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.17
       pathe: 2.0.3
       react: 19.2.8
@@ -11560,11 +11561,11 @@ snapshots:
     optionalDependencies:
       csstype: 3.2.3
 
-  '@tanstack/router-generator@1.167.21(supports-color@10.2.2)':
+  '@tanstack/router-generator@1.167.21':
     dependencies:
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
-      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
+      '@tanstack/router-utils': 1.162.2
       '@tanstack/virtual-file-routes': 1.162.0
       jiti: 2.7.0
       magic-string: 0.30.21
@@ -11573,14 +11574,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/router-plugin@1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
-      '@tanstack/router-generator': 1.167.21(supports-color@10.2.2)
-      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
+      '@tanstack/router-generator': 1.167.21
+      '@tanstack/router-utils': 1.162.2
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       zod: 4.4.3
@@ -11597,13 +11598,13 @@ snapshots:
       - supports-color
       - unloader
 
-  '@tanstack/router-utils@1.162.2(supports-color@10.2.2)':
+  '@tanstack/router-utils@1.162.2':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       ansis: 4.3.1
-      babel-dead-code-elimination: 1.0.12(supports-color@10.2.2)
+      babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
       tinyglobby: 0.2.17
@@ -11619,15 +11620,15 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.171.24(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.15
-      '@tanstack/router-generator': 1.167.21(supports-color@10.2.2)
-      '@tanstack/router-plugin': 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
+      '@tanstack/router-generator': 1.167.21
+      '@tanstack/router-plugin': 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(esbuild@0.28.1)(rolldown@1.2.0)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.17
       exsolve: 1.1.0
       lightningcss: 1.33.0
@@ -12191,9 +12192,9 @@ snapshots:
 
   astring@1.9.0: {}
 
-  babel-dead-code-elimination@1.0.12(supports-color@10.2.2):
+  babel-dead-code-elimination@1.0.12:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
@@ -13387,8 +13388,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  globrex@0.1.2: {}
-
   goober@2.1.19(csstype@3.2.3):
     dependencies:
       csstype: 3.2.3
@@ -13699,8 +13698,6 @@ snapshots:
   jimp-compact@0.16.1: {}
 
   jiti@2.7.0: {}
-
-  js-sha256@0.12.0: {}
 
   js-tokens@10.0.0: {}
 
@@ -15735,10 +15732,6 @@ snapshots:
       '@ts-morph/common': 0.29.0
       code-block-writer: 13.0.3
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tsdown@0.22.14(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39):
     dependencies:
       ansis: 4.3.1
@@ -15929,16 +15922,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  vite-tsconfig-paths@6.1.1(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "check": {
       "dependsOn": ["^check"],
-      "inputs": ["src/**"],
+      "inputs": ["src/**", "tsconfig.json", "package.json"],
       "outputLogs": "new-only"
     },
     "lint": {
@@ -18,7 +18,7 @@
     },
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**"],
+      "inputs": ["src/**", "tsdown.config.ts", "tsconfig.json", "package.json"],
       "outputs": ["dist/**", ".next/**"],
       "outputLogs": "new-only"
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,9 @@
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-  plugins: [tsconfigPaths({ projectDiscovery: 'lazy', ignoreConfigErrors: true })],
   resolve: {
     alias: { 'server-only': 'data:text/javascript,export {}' },
+    tsconfigPaths: true,
   },
   test: {
     globals: true,


### PR DESCRIPTION
Build settings and dependencies. The one source change is a Babel plugin reading `types` from the api object it is already handed.

## `unplugin-saykit` was publishing its test suite

`entry: ['src/index.ts', 'src/*.ts']` matched `src/index.test.ts`, so `dist/index.test.mjs` (538kb) and a bundled `magic-string` chunk shipped to npm. The glob now excludes tests: **574kb → 4kb.**

## turbo never rebuilt on a config change

`build.inputs` was `["src/**"]`, so edits to `tsdown.config.ts` or `package.json` hit a stale cache and left `dist` untouched — the first rebuild after changing a config returned "7 cached" and stale output. Both are inputs now, along with `tsconfig.json`; `check` gained `tsconfig.json` and `package.json` too.

## Doc comments move to the declarations

`outputOptions: { comments: { jsdoc: false } }` on every package. The comments a consumer reads in an editor come from the `.d.mts`/`.d.cts`, which keep every one of them. Nothing is minified — identifiers, formatting and `//#region` markers survive, so a stack trace still points at readable code — and `/* @__PURE__ */` annotations are preserved for downstream tree-shaking.

| Package | before | after |
| --- | --- | --- |
| unplugin-saykit | 574.7kb | 4.3kb |
| @saykit/config | 127.7kb | 107.8kb |
| saykit | 41.6kb | 27.1kb |
| @saykit/react | 19.7kb | 17.1kb |
| babel-plugin-saykit | 17.3kb | 13.1kb |
| @saykit/transform-jsx | 16.3kb | 14.6kb |
| @saykit/transform-js | 15.2kb | 13.6kb |
| @saykit/carbon | 6.9kb | 6.3kb |
| @saykit/format-json | 5.3kb | 4.8kb |
| @saykit/format-po | 2.3kb | 2.3kb |

## Two dependencies dropped

- **`@babel/core` is now a peer of `babel-plugin-saykit`.** It was a hard dependency for one runtime value, `types`, which Babel already passes to every plugin as its first argument. The import is now type-only. This is what every `babel-plugin-*` does, it drops 1.1MB plus Babel's own tree from the install for anyone who already has Babel — which, for a plugin that only runs inside Babel, is everyone — and it removes any chance of the plugin running against a different copy of Babel than its host.
- **`vite-tsconfig-paths` → vitest's own `resolve.tsconfigPaths`,** which vitest 4 had started warning about.

## Also

- `saykit` and `@saykit/react` target ES2022 rather than ES2020. Below ES2022 a `#private` field is lowered to a `WeakMap` per field plus accessor helpers, which cost 2.8kb in the runtime alone.
- `"sideEffects": false` on `saykit` and `@saykit/carbon`. Deliberately **not** on `@saykit/react`: `src/runtime/server.ts` opens with `import 'server-only'`, a bare side-effect import whose whole job is to throw when it reaches a client bundle, and declaring the package side-effect-free invites a bundler to drop exactly that guard.

## What was measured and rejected

`js-sha256` (125kb) looked like an easy swap for `node:crypto`'s `createHash`, and the ids came out byte-identical, but the playground threw "[unenv] crypto.createHash is not implemented yet!" — `unenv` leaves that entry point unimplemented, so any Nitro or workerd build of a saykit plugin would break. It is now hashed in userland again, with a comment recording why, since the Web Crypto equivalent is async and an id is resolved from a synchronous extraction pass.

`minify` in any form, whole-comment stripping, tuned treeshake options, `noExternal`, `platform: 'neutral'` — each either bought nothing over what rolldown already does, or cost readability or `@__PURE__` annotations for under 100 bytes.

Two source-level dedups in `saykit` were tried and reverted: folding `number()`/`datetime()` in `values.ts` into one factory (**−175 bytes minified, +7 gzipped**) and collapsing the six macro stubs' repeated error string into a helper (**−376 bytes minified, +6 gzipped**). gzip already deduplicates both, so each traded free repetition for structure that is not free.

Bundled size of `saykit` with its dependencies is unchanged at 20.5kb gzipped — a consumer's bundler was already stripping the comments, and the project's own code is only 3.4kb of that. Moving the number means addressing dependencies: the MF1 parser and `moo` are 5.0kb gzipped, the two skeleton parsers 5.3kb, and `messageformat` 7.2kb — the last of which is largely `DefaultFunctions` and the MF2 syntax parser, neither of which this runtime uses but neither of which can be tree-shaken through the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
