### PR TITLE
Extract translator comments from where they are written

### DIFF
--- a/.changeset/lucky-donuts-smoke.md
+++ b/.changeset/lucky-donuts-smoke.md
@@ -1,0 +1,6 @@
+---
+'@saykit/transform-jsx': patch
+'@saykit/transform-js': patch
+---
+
+Extract `// TRANSLATORS:` comments from where they are actually written — above a statement, above a selector or argument call, and as a `{/* … */}` child in JSX

--- a/packages/transform-js/src/index.test.ts
+++ b/packages/transform-js/src/index.test.ts
@@ -118,6 +118,68 @@ describe('createJsTransformer.extract', () => {
   });
 });
 
+describe('translator comments', () => {
+  const comments = (code: string) => transformer.extract(code, 'file.ts').map((m) => m.comments);
+
+  // A comment on its own line is attached to whichever node starts at it, which
+  // is almost never the message itself.
+  it.each([
+    ['an expression statement', '// TRANSLATORS: hi\nsay`Hello`;'],
+    ['a declaration', '// TRANSLATORS: hi\nconst a = say`Hello`;'],
+    ['an exported declaration', '// TRANSLATORS: hi\nexport const a = say`Hello`;'],
+    ['a default export', '// TRANSLATORS: hi\nexport default say`Hello`;'],
+    ['a return', 'function f() {\n  // TRANSLATORS: hi\n  return say`Hello`;\n}'],
+    ['an object property', 'const o = {\n  // TRANSLATORS: hi\n  a: say`Hello`,\n};'],
+    ['an array element', 'const o = [\n  // TRANSLATORS: hi\n  say`Hello`,\n];'],
+    ['a call argument', 'f(\n  // TRANSLATORS: hi\n  say`Hello`,\n);'],
+    ['a block comment', '/* TRANSLATORS: hi */\nconst a = say`Hello`;'],
+    ['the message itself', 'const a = /* TRANSLATORS: hi */ say`Hello`;'],
+  ])('reads a comment written above %s', (_, code) => {
+    expect(comments(code)).toEqual([['hi']]);
+  });
+
+  it('reads a comment written above a selector call', () => {
+    expect(comments('// TRANSLATORS: hi\nconst a = say.plural(n, { other: `days` });')).toEqual([
+      ['hi'],
+    ]);
+  });
+
+  it('reads a comment written above an argument call', () => {
+    expect(comments('// TRANSLATORS: hi\nconst a = say.number(total);')).toEqual([['hi']]);
+  });
+
+  it('keeps several comments in the order they were written', () => {
+    expect(comments('// TRANSLATORS: one\n// TRANSLATORS: two\nconst a = say`Hello`;')).toEqual([
+      ['one', 'two'],
+    ]);
+  });
+
+  it('matches the marker regardless of case', () => {
+    expect(comments('// translators: hi\nconst a = say`Hello`;')).toEqual([['hi']]);
+  });
+
+  it('ignores a comment without the marker', () => {
+    expect(comments('// a note for whoever reads this\nconst a = say`Hello`;')).toEqual([[]]);
+  });
+
+  it('takes only the marked comment out of a run of them', () => {
+    expect(comments('// a note\n// TRANSLATORS: hi\nconst a = say`Hello`;')).toEqual([['hi']]);
+  });
+
+  // A statement is as wide as attribution goes: a comment above a function
+  // describes the function, not every message written inside it.
+  it('does not reach past the statement holding the message', () => {
+    expect(comments('// TRANSLATORS: hi\nfunction f() {\n  return say`Hello`;\n}')).toEqual([[]]);
+  });
+
+  it('does not carry a comment on to the next message', () => {
+    expect(comments('// TRANSLATORS: hi\nconst a = say`Hello`;\nconst b = say`Bye`;')).toEqual([
+      ['hi'],
+      [],
+    ]);
+  });
+});
+
 describe('createJsTransformer.transform', () => {
   it('rewrites a tagged template into a `.call`', () => {
     const output = transformer.transform('const greeting = say`Hello, ${name}!`;', 'file.ts');

--- a/packages/transform-js/src/index.ts
+++ b/packages/transform-js/src/index.ts
@@ -4,7 +4,7 @@ import traverse_ from '@babel/traverse';
 import type { Transformer } from '@saykit/config';
 import { assignSequenceIdentifiers, CompositeMessage } from '@saykit/config/features/messages';
 import { generateSayCallExpression } from './generator.js';
-import { isEquivalentPlaceholder, parseExpression } from './parser.js';
+import { collectLeadingComments, isEquivalentPlaceholder, parseExpression } from './parser.js';
 
 const traverse = ((traverse_ as any).default || traverse_) as typeof traverse_;
 
@@ -43,7 +43,10 @@ function createJsTransformer(): Transformer {
 
       traverse(program, {
         Expression(path) {
-          path.node.leadingComments = path.node.leadingComments ?? [];
+          // Only extraction cares where a comment was written — the transform
+          // leaves comments where they are, and moving them would duplicate
+          // them into the generated call.
+          path.node.leadingComments = collectLeadingComments(path);
           const message = parseExpression(path.node);
           if (message) {
             assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
@@ -69,7 +72,6 @@ function createJsTransformer(): Transformer {
 
       traverse(program, {
         Expression(path) {
-          path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
             assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);

--- a/packages/transform-js/src/parser.test.ts
+++ b/packages/transform-js/src/parser.test.ts
@@ -1,4 +1,5 @@
-import { parseExpression } from '@babel/parser';
+import { parse, parseExpression } from '@babel/parser';
+import traverse_ from '@babel/traverse';
 import * as t from '@babel/types';
 import {
   ArgumentMessage,
@@ -10,6 +11,8 @@ import {
 } from '@saykit/config/features/messages';
 import { describe, expect, it } from 'vitest';
 import * as parser from './parser.js';
+
+const traverse = ((traverse_ as any).default || traverse_) as typeof traverse_;
 
 // Parse a snippet of real source into its expression node, the way the
 // transformer does (see index.ts). `test.js` becomes the reference filename.
@@ -227,6 +230,18 @@ describe('parseCallExpression', () => {
     const call = expr<t.CallExpression>("say.plural(count, { other: 'x' })");
     call.loc = null;
     expect(parser.parseCallExpression(call)!.references).toEqual([]);
+  });
+
+  it('extracts translator comments', () => {
+    const result = parser.parseCallExpression(
+      expr<t.CallExpression>('// Translators: Round the total\nsay.number(total)'),
+    );
+    expect(result!.comments).toEqual(['Round the total']);
+  });
+
+  it('ignores non-translator leading comments', () => {
+    const result = parser.parseCallExpression(expr('// just a note\nsay.number(total)'));
+    expect(result!.comments).toEqual([]);
   });
 
   it('parses a select call expression', () => {
@@ -610,5 +625,98 @@ describe('isEquivalentPlaceholder, on values', () => {
   it('treats anything that is not a node as distinguishable', () => {
     expect(parser.isEquivalentPlaceholder(null, null)).toBe(false);
     expect(parser.isEquivalentPlaceholder(expr('name'), undefined)).toBe(false);
+  });
+});
+
+describe('collectLeadingComments', () => {
+  // The JSX parser reaches these paths through this package, so they are
+  // exercised here against the source rather than the built dependency.
+  function collect(code: string, find: (node: t.Node) => boolean) {
+    const ast = parse(code, {
+      sourceType: 'module',
+      sourceFilename: 'test.tsx',
+      plugins: ['typescript', 'jsx'],
+      attachComment: true,
+      tokens: true,
+      ranges: true,
+    });
+
+    let comments: readonly t.Comment[] = [];
+    traverse(ast, {
+      enter(path) {
+        if (!find(path.node)) return;
+        comments = parser.collectLeadingComments(path);
+        path.stop();
+      },
+    });
+    return comments.map((c) => c.value.trim());
+  }
+
+  const say = (node: t.Node) => t.isTaggedTemplateExpression(node);
+  const element = (node: t.Node) =>
+    t.isJSXElement(node) &&
+    t.isJSXIdentifier(node.openingElement.name) &&
+    node.openingElement.name.name === 'Say';
+
+  it('walks out to the statement holding the message', () => {
+    expect(collect('// a note\nconst a = say`Hi`;', say)).toEqual(['a note']);
+  });
+
+  it('walks out through an export to the declaration it wraps', () => {
+    expect(collect('// a note\nexport const a = say`Hi`;', say)).toEqual(['a note']);
+  });
+
+  it('stops at the statement', () => {
+    expect(collect('// a note\nfunction f() {\n  return say`Hi`;\n}', say)).toEqual([]);
+  });
+
+  it('reads a comment child in front of a JSX message', () => {
+    expect(collect('const x = <p>{/* a note */}<Say>Hi</Say></p>;', element)).toEqual(['a note']);
+  });
+
+  it('reads a comment child in front of a JSX message in a fragment', () => {
+    expect(collect('const x = <>{/* a note */}<Say>Hi</Say></>;', element)).toEqual(['a note']);
+  });
+
+  it('reads through the whitespace laying out the markup', () => {
+    expect(
+      collect('const x = (\n  <p>\n    {/* a note */}\n    <Say>Hi</Say>\n  </p>\n);', element),
+    ).toEqual(['a note']);
+  });
+
+  it('stops at a child that is not a comment', () => {
+    expect(collect('const x = <p>{/* a note */}<b>x</b><Say>Hi</Say></p>;', element)).toEqual([]);
+  });
+
+  it('stops at an expression child holding something other than a comment', () => {
+    expect(collect('const x = <p>{/* a note */}{value}<Say>Hi</Say></p>;', element)).toEqual([]);
+  });
+
+  it('reads an empty expression child that holds no comment as nothing', () => {
+    expect(collect('const x = <p>{}<Say>Hi</Say></p>;', element)).toEqual([]);
+  });
+
+  it('does not reach out of a child list to the statement around it', () => {
+    expect(collect('// a note\nconst x = <p><Say>Hi</Say></p>;', element)).toEqual([]);
+  });
+
+  it('reports a comment once when an ancestor already carries it', () => {
+    // The transformer assigns what this collects back on to the node, so a
+    // second pass over the same tree must not double the comment up.
+    const ast = parse('// a note\nconst a = say`Hi`;', {
+      sourceType: 'module',
+      attachComment: true,
+      tokens: true,
+      ranges: true,
+    });
+
+    let collected: readonly t.Comment[] = [];
+    traverse(ast, {
+      Expression(path) {
+        path.node.leadingComments = parser.collectLeadingComments(path);
+        if (t.isTaggedTemplateExpression(path.node)) collected = path.node.leadingComments;
+      },
+    });
+    expect(collected.map((c) => c.value.trim())).toEqual(['a note']);
   });
 });

--- a/packages/transform-js/src/parser.ts
+++ b/packages/transform-js/src/parser.ts
@@ -1,3 +1,4 @@
+import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import {
   ArgumentMessage,
@@ -32,7 +33,7 @@ export function parseTaggedTemplateExpression(
 
   return new CompositeMessage(
     { id: descriptorId, context: descriptorContext },
-    getTranslatorComments(tagged.leadingComments ?? []),
+    getTranslatorComments(tagged.leadingComments),
     tagged.loc ? [`${tagged.loc.filename}:${tagged.loc.start.line}`] : [],
     children,
     accessor,
@@ -67,7 +68,7 @@ export function parseCallExpression(call: t.CallExpression): CompositeMessage | 
   const wrap = (children: Message[]) =>
     new CompositeMessage(
       { id: descriptorId, context: descriptorContext },
-      [],
+      getTranslatorComments(call.leadingComments),
       call.loc ? [`${call.loc.filename}:${call.loc.start.line}`] : [],
       children,
       accessor,
@@ -305,10 +306,80 @@ function findPropertyValueIfStringLiteralAsString(object: t.ObjectExpression, ke
   return undefined;
 }
 
-function getTranslatorComments(comments: t.Comment[]) {
-  return comments.reduce<string[]>((a, c) => {
+const TRANSLATOR_COMMENT_PREFIX = 'translators:';
+
+/**
+ * The notes a translator is meant to read, taken from the comments written
+ * above a message — `// TRANSLATORS: keep this under 20 characters`. A comment
+ * that does not open with the marker is a note to whoever is reading the code,
+ * and stays there.
+ */
+export function getTranslatorComments(comments: readonly t.Comment[] | null | undefined) {
+  return (comments ?? []).reduce<string[]>((a, c) => {
     const text = c.value.trim();
-    if (text.toLowerCase().startsWith('translators:')) a.push(text.slice(12).trim());
+    if (text.toLowerCase().startsWith(TRANSLATOR_COMMENT_PREFIX))
+      a.push(text.slice(TRANSLATOR_COMMENT_PREFIX.length).trim());
     return a;
   }, []);
+}
+
+/**
+ * The comments written in front of a message, in the order they were written.
+ *
+ * A comment on its own line is attached by Babel to whatever node happens to
+ * begin at it — `const a = say\`Hi\`` puts it on the declaration, not on the
+ * template — so a message is rarely the node holding its own notes. Walking out
+ * to the statement gathers them from wherever they landed.
+ */
+export function collectLeadingComments(path: NodePath<t.Node>) {
+  const levels: (readonly t.Comment[])[] = [];
+  let current: NodePath<t.Node> | null = path;
+
+  while (current) {
+    levels.push(current.node.leadingComments ?? []);
+
+    const parent: NodePath<t.Node> | null = current.parentPath;
+    // Only a program has nothing around it, and a program is not a message.
+    /* v8 ignore next */
+    if (!parent) break;
+
+    // Among JSX children a comment is written as `{/* … */}`, an element of the
+    // list rather than something attached to the element it describes.
+    if (t.isJSXElement(parent.node) || t.isJSXFragment(parent.node)) {
+      levels.push(getPrecedingJSXComments(parent.node, current.node));
+      break;
+    }
+
+    // A statement is the widest thing a comment above a message can belong to —
+    // anything further out wraps code the message is only one part of. An
+    // export is the exception, being a wrapper around the statement itself.
+    if (t.isStatement(current.node) && !t.isExportDeclaration(parent.node)) break;
+
+    current = parent;
+  }
+
+  // Innermost first on the way up, and outermost first in the source. A comment
+  // that landed on an ancestor is also reachable through a descendant whose own
+  // list this traversal already filled in, so identity dedupes the overlap.
+  return [...new Set(levels.reverse().flat())];
+}
+
+/**
+ * The comments in the `{/* … *\/}` children standing immediately in front of an
+ * element, which is how a comment about a message is written inside JSX. Only
+ * the whitespace that lays the markup out may come between them.
+ */
+function getPrecedingJSXComments(parent: t.JSXElement | t.JSXFragment, node: t.Node) {
+  const index = parent.children.indexOf(node as t.JSXElement);
+  /* v8 ignore next */
+  if (index === -1) return [];
+
+  const comments: t.Comment[] = [];
+  for (let i = index - 1; i >= 0; i--) {
+    const sibling = parent.children[i]!;
+    if (t.isJSXText(sibling) && !sibling.value.trim()) continue;
+    if (!t.isJSXExpressionContainer(sibling) || !t.isJSXEmptyExpression(sibling.expression)) break;
+    comments.unshift(...(sibling.expression.innerComments ?? []));
+  }
+  return comments;
 }

--- a/packages/transform-jsx/src/index.test.ts
+++ b/packages/transform-jsx/src/index.test.ts
@@ -167,6 +167,67 @@ describe('createJsxTransformer.extract', () => {
   });
 });
 
+describe('translator comments', () => {
+  const comments = (code: string) => transformer.extract(code, 'file.tsx').map((m) => m.comments);
+
+  it.each([
+    ['a declaration', '// TRANSLATORS: hi\nconst x = <Say>Hello</Say>;'],
+    ['a return', 'function C() {\n  // TRANSLATORS: hi\n  return <Say>Hello</Say>;\n}'],
+    ['an implicit return', 'const C = () => (\n  // TRANSLATORS: hi\n  <Say>Hello</Say>\n);'],
+    ['a self-closing element', '// TRANSLATORS: hi\nconst x = <Say.Number _={total} />;'],
+  ])('reads a comment written above %s', (_, code) => {
+    expect(comments(code)).toEqual([['hi']]);
+  });
+
+  it('reads a comment written above a tagged template in an attribute', () => {
+    expect(
+      comments('const x = (\n  <B\n    // TRANSLATORS: hi\n    label={say`Hello`}\n  />\n);'),
+    ).toEqual([['hi']]);
+  });
+
+  // Among children there is no node in front of the element for a comment to
+  // attach to, so JSX writes one as a child of its own.
+  it('reads a comment child standing in front of the message', () => {
+    expect(
+      comments(
+        'const x = (\n  <div>\n    {/* TRANSLATORS: hi */}\n    <Say>Hello</Say>\n  </div>\n);',
+      ),
+    ).toEqual([['hi']]);
+  });
+
+  it('reads a comment child standing in front of a self-closing message', () => {
+    expect(
+      comments(
+        'const x = (\n  <div>\n    {/* TRANSLATORS: hi */}\n    <Say.Number _={total} />\n  </div>\n);',
+      ),
+    ).toEqual([['hi']]);
+  });
+
+  it('keeps several comment children in the order they were written', () => {
+    expect(
+      comments(
+        'const x = (\n  <div>\n    {/* TRANSLATORS: one */}\n    {/* TRANSLATORS: two */}\n    <Say>Hello</Say>\n  </div>\n);',
+      ),
+    ).toEqual([['one', 'two']]);
+  });
+
+  it('ignores a comment child something else stands between', () => {
+    expect(
+      comments(
+        'const x = (\n  <div>\n    {/* TRANSLATORS: hi */}\n    <b>x</b>\n    <Say>Hello</Say>\n  </div>\n);',
+      ),
+    ).toEqual([[]]);
+  });
+
+  // The comment above the statement describes the markup, and there is no
+  // saying which of the messages inside it was meant.
+  it('does not reach out of a child list to the statement around it', () => {
+    expect(
+      comments('// TRANSLATORS: hi\nconst x = (\n  <div>\n    <Say>Hello</Say>\n  </div>\n);'),
+    ).toEqual([[]]);
+  });
+});
+
 describe('createJsxTransformer.transform', () => {
   it('rewrites a Say element into a self-closing Say with an id', () => {
     const output = transformer.transform(

--- a/packages/transform-jsx/src/index.ts
+++ b/packages/transform-jsx/src/index.ts
@@ -4,7 +4,11 @@ import traverse_ from '@babel/traverse';
 import type { Transformer } from '@saykit/config';
 import { assignSequenceIdentifiers, CompositeMessage } from '@saykit/config/features/messages';
 import { generateSayCallExpression } from '@saykit/transform-js/generator';
-import { isEquivalentPlaceholder, parseExpression } from '@saykit/transform-js/parser';
+import {
+  collectLeadingComments,
+  isEquivalentPlaceholder,
+  parseExpression,
+} from '@saykit/transform-js/parser';
 import { generateSayJSXElement } from './generator.js';
 import { parseJSXElement } from './parser.js';
 
@@ -45,7 +49,10 @@ function createJsxTransformer(): Transformer {
 
       traverse(program, {
         Expression(path) {
-          path.node.leadingComments = path.node.leadingComments ?? [];
+          // Only extraction cares where a comment was written — the transform
+          // leaves comments where they are, and moving them would duplicate
+          // them into the generated call.
+          path.node.leadingComments = collectLeadingComments(path);
           const message = parseExpression(path.node);
           if (message) {
             assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
@@ -55,7 +62,7 @@ function createJsxTransformer(): Transformer {
         },
 
         JSXElement(path) {
-          path.node.leadingComments = path.node.leadingComments ?? [];
+          path.node.leadingComments = collectLeadingComments(path);
           const message = parseJSXElement(path.node);
           if (message) {
             assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
@@ -81,7 +88,6 @@ function createJsxTransformer(): Transformer {
 
       traverse(program, {
         Expression(path) {
-          path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseExpression(path.node);
           if (message) {
             assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);
@@ -92,7 +98,6 @@ function createJsxTransformer(): Transformer {
         },
 
         JSXElement(path) {
-          path.node.leadingComments = path.node.leadingComments ?? [];
           const message = parseJSXElement(path.node);
           if (message) {
             assignSequenceIdentifiers(message, { current: 0 }, isEquivalentPlaceholder);

--- a/packages/transform-jsx/src/parser.ts
+++ b/packages/transform-jsx/src/parser.ts
@@ -11,7 +11,7 @@ import {
   validateBranchIdentifier,
   type Message,
 } from '@saykit/config/features/messages';
-import { unwrapPlaceholder } from '@saykit/transform-js/parser';
+import { getTranslatorComments, unwrapPlaceholder } from '@saykit/transform-js/parser';
 
 /**
  * Attribute used to name the ICU tag an embedded element extracts as, e.g.
@@ -43,7 +43,7 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
 
   return new CompositeMessage(
     { id: descriptorId, context: descriptorContext },
-    [],
+    getTranslatorComments(element.leadingComments),
     getReferences(element),
     children,
     accessor as t.Expression,
@@ -51,7 +51,15 @@ export function parseJSXContainerElement(element: t.JSXElement): CompositeMessag
   );
 }
 
-export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeMessage | null {
+/**
+ * A self-closing `Say` element. Comments are passed in rather than read off the
+ * node, since they were written in front of the element as a whole and Babel
+ * attaches them there.
+ */
+export function parseJSXOpeningElement(
+  element: t.JSXOpeningElement,
+  comments?: readonly t.Comment[] | null,
+): CompositeMessage | null {
   if (!element.selfClosing) return null;
   const processed = processJSXOpeningElement(element);
   if (!processed) return null;
@@ -66,7 +74,7 @@ export function parseJSXOpeningElement(element: t.JSXOpeningElement): CompositeM
   const wrap = (children: Message[]) =>
     new CompositeMessage(
       { id: descriptorId, context: descriptorContext },
-      [],
+      getTranslatorComments(comments),
       getReferences(element),
       children,
       accessor as t.Expression,
@@ -265,7 +273,7 @@ export function parseJSXElement(
 ): CompositeMessage | ElementMessage;
 export function parseJSXElement(element: t.JSXElement, fallback?: boolean): Message | null {
   const message = element.openingElement.selfClosing
-    ? parseJSXOpeningElement(element.openingElement)
+    ? parseJSXOpeningElement(element.openingElement, element.leadingComments)
     : parseJSXContainerElement(element);
 
   if (message) return message;

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -454,10 +454,10 @@ string attribute has nowhere to put a value:
 
 <Callout type="info">
   A message extracts as the text JSX renders, so a line break and the indentation around it are
-  layout and never reach a catalogue. Whitespace that has to survive a break is written as ` ` — the
-  same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the space
-  it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is read
-  the same way, as the text it renders as.
+  layout and never reach a catalogue. Whitespace that has to survive a break is written as{' '}
+  <code>{"{' '}"}</code> — the same escape Prettier inserts when it wraps a line ending in a space —
+  and it extracts as the space it renders as, not as a placeholder. A literal expression child such
+  as `{'—'}` or `{10}` is read the same way, as the text it renders as.
 </Callout>
 
 <Callout type="info">

--- a/website/content/core-concepts/messages.mdx
+++ b/website/content/core-concepts/messages.mdx
@@ -378,6 +378,24 @@ msgid "Sign in"
 msgstr "Sign in"
 ```
 
+The comment belongs to the statement the message is written in, so it can sit above a declaration, a `return`, an object property, or the message itself:
+
+```ts
+// TRANSLATORS: Shown while the report is generating
+const label = say`One moment…`;
+```
+
+It doesn't reach any further than that statement — a comment above a function describes the function, not every message inside it.
+
+Inside JSX there is nothing in front of an element for a comment to attach to, so write one as a child instead:
+
+```tsx
+<div>
+  {/* TRANSLATORS: Button text, keep under 20 characters */}
+  <Say>Continue</Say>
+</div>
+```
+
 Use them when:
 
 - the meaning of a message isn't obvious from the text
@@ -436,10 +454,10 @@ string attribute has nowhere to put a value:
 
 <Callout type="info">
   A message extracts as the text JSX renders, so a line break and the indentation around it are
-  layout and never reach a catalogue. Whitespace that has to survive a break is written as `{' '}` —
-  the same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the
-  space it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is
-  read the same way, as the text it renders as.
+  layout and never reach a catalogue. Whitespace that has to survive a break is written as ` ` — the
+  same escape Prettier inserts when it wraps a line ending in a space — and it extracts as the space
+  it renders as, not as a placeholder. A literal expression child such as `{'—'}` or `{10}` is read
+  the same way, as the text it renders as.
 </Callout>
 
 <Callout type="info">

--- a/website/content/integrations/react.mdx
+++ b/website/content/integrations/react.mdx
@@ -116,7 +116,8 @@ an ICU skeleton, which is how you ask for a currency or for fields the named sty
 See [Messages](/core-concepts/messages#numbers-dates-and-times) for what each one extracts to.
 
 <Callout type="info">
-  The `{' '}` spacing escape is safe inside a `<Say>`. A literal expression child is read as the text
+  The <code>{"{' '}"}</code> spacing escape is safe inside a `<Say>`. A literal expression child is
+  read as the text
   it renders as, so it folds into the words around it and reaches a translator as one run of text
   rather than as a placeholder they can neither see nor move.
 </Callout>


### PR DESCRIPTION
`// TRANSLATORS:` comments were never reaching the catalogue in real code.

Babel attaches an own-line comment to whichever node begins at it — for `// TRANSLATORS: hi` above `const a = say\`Hello\`` that is the `VariableDeclaration`, not the tagged template. The parser only read `tagged.leadingComments`, so it saw nothing. Selector and argument calls (`say.plural`, `say.number`) hardcoded `[]`, and the JSX parser had no comment support at all.

The only form that worked was an inline block comment on the same line: `const a = /* TRANSLATORS: hi */ say\`Hello\``.

The existing test passed because it called `parseExpression()` on a bare expression string, which attaches the comment straight to the template — a shape real files never produce.

## Changes

- `collectLeadingComments(path)` walks from the message out to the statement holding it, gathering comments from wherever they landed. It climbs through an `export` wrapper, stops at the statement, and dedupes by identity.
- `getPrecedingJSXComments` reads `{/* … */}` children standing in front of an element, through layout whitespace only.
- `parseCallExpression` and both JSX parse entry points now read comments instead of hardcoding `[]`.
- Extract visitors collect; transform visitors do not, since moving comments there would duplicate them into the generated call. The three `leadingComments ?? []` no-ops are gone.

## Now working

| Placement | JS | JSX |
| --- | --- | --- |
| Above statement / declaration / `return` / export | ✅ | ✅ |
| Above object property, array element, call argument | ✅ | — |
| Same line, inline block comment | ✅ | ✅ |
| `say.plural` / `.select` / `.ordinal` / `.number` | ✅ | ✅ |
| `{/* TRANSLATORS: … */}` child before element | — | ✅ |
| Above a JSX attribute holding a tagged template | — | ✅ |

Deliberately not matched: a comment above a function wrapping many messages, and a statement comment reaching into a JSX child list. Both would attach one note to several unrelated entries.

Multiple consecutive markers are kept in source order, unmarked comments are still ignored, and the marker stays case-insensitive.

## Notes

- `transform-jsx` resolves `@saykit/transform-js` to `dist`, so JSX-side execution of the shared parser never counts toward source coverage. `collectLeadingComments` therefore has direct unit tests in `transform-js/src/parser.test.ts` alongside the end-to-end placement tests in both `index.test.ts` files.
- Docs updated in `messages.mdx` with the scope rule and the JSX form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Translator comments are now captured from JavaScript statements, selectors, calls, tagged templates, and JSX elements or children.
  - Comment matching is case-insensitive, preserves ordering, and avoids duplicates or unrelated comments.

- **Documentation**
  - Added guidance for placing translator comments in JavaScript and JSX.
  - Clarified how to represent literal spaces in JSX content.

- **Bug Fixes**
  - Improved comment association across statement, expression, and JSX boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->